### PR TITLE
FEATURE: add a "repo import into editor projects" command to new toolkit

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -15,7 +15,7 @@ export def "import" [--into: string@"nu-complete import-targets"] {
     }
 
     let projects = (match $into {
-        "neovim" => { $env.HOME | path join ".local/share/nvim/project_nvim/project_history" },
+        "neovim" => { $env.HOME | path join ".local" "share" "nvim" "project_nvim" "project_history" },
         _ => {
             print $"(ansi red) '(ansi red_italic)($into)' is not a valid target.(ansi reset)"
             return

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -1,0 +1,42 @@
+def pretty-cmd [] {
+    let cmd = $in
+    $"(ansi -e {fg: default attr: di})($cmd)(ansi reset)"
+
+}
+
+def "nu-complete import-targets" [] {
+    ["neovim"]
+}
+
+export def "import" [--into: string@"nu-complete import-targets"] {
+    if ($into == null) {
+        print $"(ansi red_italic)--into is a required argument.(ansi reset)"
+        return
+    }
+
+    let projects = (match $into {
+        "neovim" => { $env.HOME | path join ".local/share/nvim/project_nvim/project_history" },
+        _ => {
+            print $"(ansi red) '(ansi red_italic)($into)' is not a valid target.(ansi reset)"
+            return
+        },
+    })
+
+    mkdir ($projects | path dirname)
+    touch $projects
+
+    let before = ($projects | open | lines | length)
+
+    $projects | open | lines | append (
+        ghq list
+        | lines
+        | each {|it|
+            print $"adding (ansi yellow)($it)(ansi reset) to the projects..."
+            ghq root | str trim | path join $it
+        }
+    ) | uniq
+    | save -f $projects
+
+    print $"all ('git' | pretty-cmd) projects (ansi green_bold)successfully imported(ansi reset) into the ($projects | pretty-cmd) list!"
+    print $"from ($before) to ($projects | open | lines | length) projects."
+}

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -28,11 +28,11 @@ export def "import" [--into: string@"nu-complete import-targets"] {
     let before = ($projects | open | lines | length)
 
     $projects | open | lines | append (
-        ghq list
+        ghq list  # FIXME: do not use `ghq` as the main dependency
         | lines
         | each {|it|
             print $"adding (ansi yellow)($it)(ansi reset) to the projects..."
-            ghq root | str trim | path join $it
+            ghq root | str trim | path join $it  # FIXME: do not use `ghq` as the main dependency
         }
     ) | uniq
     | save -f $projects

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -14,6 +14,7 @@ export def "import" [--into: string@"nu-complete import-targets"] {
         return
     }
 
+    # TODO: replace projects with a config value.
     let projects = (match $into {
         "neovim" => { $env.HOME | path join ".local" "share" "nvim" "project_nvim" "project_history" },
         _ => {


### PR DESCRIPTION
This comes from my [`kickstart.nvim` config](https://github.com/goatfiles/kickstart.nvim/blob/master/toolkit.nu#L22-L48).

because `nu-git-manager` will manage a bunch of `git` repos, i think having a little tool to load all of them at once in a "projects manager" is nice.

this PR:
- adds a `toolkit.nu` module to `nu-git-manager`
> **Note**
> such a module can be loaded automatically upon entering the root of the repo locally with an [`env_change` hook](https://github.com/goatfiles/dotfiles/blob/nightly/.config/nushell/lib/core/hooks.nu#L20-L32)
- adds a bit of completion to it
- adds the `--into` option which now supports *neovim*
- adds `FIXME`s to not forget about the `ghq` dependency