### PR TITLE
REFACTOR: merge `git grab` and `clone`

### DIFF
--- a/mod.nu
+++ b/mod.nu
@@ -27,12 +27,15 @@ export def-env "git grab select" [] {
 # TODO: add support for other hosts than github
 # TODO: better worktree support
 
+# Clone a repository into a standard location
+#
+# This place is organised by domain and path.
 export def "git grab" [
-    owner: string
-    repo: string
-    --host: string = "github.com"
-    --ssh (-s): bool
-    --bare (-b): bool
+    owner: string                 # the name of the owner of the repo.
+    repo: string                  # the name of the repo to grab.
+    --host: string = "github.com" # the host to grab the repo from.
+    --ssh (-s): bool              # use ssh instead of https.
+    --bare (-b): bool             # clone as *bare* repo (specific to worktrees).
 ] {
     let url = (if $ssh {
         $"git@($host):($owner)/($repo).git"

--- a/mod.nu
+++ b/mod.nu
@@ -1,11 +1,3 @@
-def log_success [message: string] {
-    print $"(ansi green)($message)(ansi reset)"
-}
-
-def log_warning [message: string] {
-    print $"(ansi yellow)($message)(ansi reset)"
-}
-
 def root_dir [owner?: string] {
     $env.GIT_REPOS_HOME?
     | default ($nu.home-path | path join "dev")

--- a/mod.nu
+++ b/mod.nu
@@ -37,78 +37,24 @@ export def-env "git grab select" [] {
 # TODO: add support for other hosts than github
 # TODO: better worktree support
 
-# Clone a github repository into a standard location organised by domain and path.
-export def-env "git grab" [
-    owner,          # Either the owner, your repo name, or "owner/repo"
-    repo?: string,  # the repo name
-    --ssh           # use ssh instead of https
-    --bare(-b)      # use a bare repo (specific to worktrees)
-] {
-    let username = (git config user.username | str trim)
-
-    let info = (
-        if ($repo == null) {
-            let inf = ($owner | split row '/' )
-            if ($inf | length) == 1 {
-                { owner:$username, repo: ($inf.0) }
-            } else {
-                { owner:($inf.0), repo: ($inf.1) }
-            }
-        } else {
-            { owner: $owner, repo: $repo }
-        }
-    )
-
-    let dir = (root_dir $info.owner)
-    let repo_path = ($dir | path join $info.repo)
-
-    let repo_path = if $bare { $"($repo_path).git" } else { $repo_path }
-
-    if ($repo_path | path exists) {
-        log_warning "Found an existing repo, we will cd to it."
-        cd $repo_path
-        return
-    }
-
-    log_success $"Cloning into ($repo_path)"
-
-    mkdir $dir
-    cd $dir
-
-    let url = if ($ssh) {
-        $"git@github.com:($info.owner)/($info.repo).git"
-    } else {
-        $"https://github.com/($info.owner)/($info.repo).git"
-    }
-
-    if $bare {
-        git clone --bare --recurse-submodules $url
-        cd $repo_path
-
-        log_success "Setting up worktrees"
-
-        mkdir .bare
-        mv * .bare
-        "gitdir: ./.bare" | save .git
-    } else {
-        git clone --recurse-submodules $url
-        cd $repo_path
-    }
-
-    log_success "Done"
-}
-
-export def clone [
+export def "git grab" [
     owner: string
     repo: string
     --host: string = "github.com"
-    --protocol: string = "https"
-] {(
-    git clone --recurse-submodules
-        ({
-            scheme: $protocol,
-            host: $host,
-            path: $"/($owner)/($repo)",
-        } | url join)
-        (root_dir $owner | path join $repo)
-)}
+    --ssh (-s): bool
+    --bare (-b): bool
+] {
+    let url = (if $ssh {
+        $"git@($host):($owner)/($repo).git"
+    } else {
+        $"https://($host)/($owner)/($repo).git"
+    })
+
+    let local = (root_dir | path join $host $owner $repo)
+
+    if $bare {
+        git clone --bare --recurse-submodules $url $local
+    } else {
+        git clone --recurse-submodules $url $local
+    }
+}

--- a/mod.nu
+++ b/mod.nu
@@ -1,7 +1,5 @@
-def root_dir [owner?: string] {
-    $env.GIT_REPOS_HOME?
-    | default ($nu.home-path | path join "dev")
-    | if ($owner != null) { path join $owner } else {}
+def root_dir [] {
+    $env.GIT_REPOS_HOME? | default ($nu.home-path | path join "dev")
 }
 
 # TODO: support cancel


### PR DESCRIPTION
this PR
- merges `git grab` and `clone` together
- removes the `log` commands which are not used anymore (and we can use the standard library :smirk:)
- `root_dir` now only computes the root dir without subdirectory, i do that with `path join` only

> **Note**
> some features to take care of
> - more logging?
> - what happens when the repo already exists? `cd` into it? update it with `-u`?
> - do not put the repos under `$host` with an option / config