### PR TITLE
FIX: do not use completion when outside `git` repo

### DIFF
--- a/completions.nu
+++ b/completions.nu
@@ -1,3 +1,8 @@
+def is-git-repo [] {
+  not (do -i {
+    git rev-parse --is-inside-work-tree
+  } | is-empty)
+}
 
 def "nu-complete git available upstream" [] {
   ^git branch -a | lines | each { |line| $line | str replace '\* ' "" | str trim }

--- a/completions.nu
+++ b/completions.nu
@@ -5,35 +5,49 @@ def is-git-repo [] {
 }
 
 def "nu-complete git available upstream" [] {
+  if not (is-git-repo) { return }
+
   ^git branch -a | lines | each { |line| $line | str replace '\* ' "" | str trim }
 }
 
 def "nu-complete git remotes" [] {
+  if not (is-git-repo) { return }
+
   ^git remote | lines | each { |line| $line | str trim }
 }
 
 def "nu-complete git log" [] {
+  if not (is-git-repo) { return }
+
   ^git log --pretty=%h | lines | each { |line| $line | str trim }
 }
 
 # Yield all existing commits in descending chronological order.
 def "nu-complete git commits all" [] {
+  if not (is-git-repo) { return }
+
   ^git rev-list --all --remotes --pretty=oneline | lines | parse "{value} {description}"
 }
 
 # Yield commits of current branch only. This is useful for e.g. cut points in
 # `git rebase`.
 def "nu-complete git commits current branch" [] {
+  if not (is-git-repo) { return }
+
   ^git log --pretty="%h %s" | lines | parse "{value} {description}"
 }
 
 # Yield local branches like `main`, `feature/typo_fix`
 def "nu-complete git local branches" [] {
+  if not (is-git-repo) { return }
+
   ^git branch | lines | each { |line| $line | str replace '\* ' "" | str trim }
 }
 
 # Yield remote branches like `origin/main`, `upstream/feature-a`
 def "nu-complete git remote branches with prefix" [] {
+  if not (is-git-repo) { return }
+
   ^git branch -r | lines | parse -r '^\*?(\s*|\s*\S* -> )(?P<branch>\S*$)' | get branch | uniq
 }
 
@@ -41,6 +55,8 @@ def "nu-complete git remote branches with prefix" [] {
 # E.g. `upstream/feature-a` as `feature-a` to checkout and track in one command
 # with `git checkout` or `git switch`.
 def "nu-complete git remote branches nonlocal without prefix" [] {
+  if not (is-git-repo) { return }
+
   # Get regex to strip remotes prefixes. It will look like `(origin|upstream)`
   # for the two remotes `origin` and `upstream`.
   let remotes_regex = (["(", ((nu-complete git remotes | each {|r| [$r, '/'] | str join}) | str join "|"), ")"] | str join)
@@ -49,6 +65,8 @@ def "nu-complete git remote branches nonlocal without prefix" [] {
 }
 
 def "nu-complete git switch" [] {
+  if not (is-git-repo) { return }
+
   (nu-complete git local branches)
   | parse "{value}"
   | insert description "local branch"
@@ -58,6 +76,8 @@ def "nu-complete git switch" [] {
 }
 
 def "nu-complete git checkout" [] {
+  if not (is-git-repo) { return }
+
   (nu-complete git local branches)
   | parse "{value}"
   | insert description "local branch"
@@ -72,6 +92,8 @@ def "nu-complete git checkout" [] {
 
 # Arguments to `git rebase --onto <arg1> <arg2>`
 def "nu-complete git rebase" [] {
+  if not (is-git-repo) { return }
+
   (nu-complete git local branches)
   | parse "{value}"
   | insert description "local branch"
@@ -82,18 +104,26 @@ def "nu-complete git rebase" [] {
 }
 
 def "nu-complete git stash-list" [] {
+  if not (is-git-repo) { return }
+
   git stash list | lines | parse "{value}: {description}"
 }
 
 def "nu-complete git tags" [] {
+  if not (is-git-repo) { return }
+
   ^git tag | lines
 }
 
 def "nu-complete git built-in-refs" [] {
+  if not (is-git-repo) { return }
+
   [HEAD FETCH_HEAD ORIG_HEAD]
 }
 
 def "nu-complete git refs" [] {
+  if not (is-git-repo) { return }
+
   nu-complete git switchable branches
   | parse "{value}"
   | insert description Branch
@@ -102,6 +132,8 @@ def "nu-complete git refs" [] {
 }
 
 def "nu-complete git subcommands" [] {
+  if not (is-git-repo) { return }
+
   ^git help -a | lines | where $it starts-with "   " | parse -r '\s*(?P<value>[^ ]+) \s*(?P<description>\w.*)'
 }
 


### PR DESCRIPTION
i've noticed [this bug](https://asciinema.org/a/582021) when using the completion outside of a `git` repo :open_mouth: 

this PR adds the `is-git-repo` command to `completions.nu` and early quit all the completion commands when not in a `git` repo => see the [new behaviour](https://asciinema.org/a/582030).

## make sure all commands have been modified
running
```
rg 'def "nu-complete' -A 1
```
gives
```
completions.nu:def "nu-complete git available upstream" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git remotes" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git log" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git commits all" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git commits current branch" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git local branches" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git remote branches with prefix" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git remote branches nonlocal without prefix" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git switch" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git checkout" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git rebase" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git stash-list" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git tags" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git built-in-refs" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git refs" [] {
completions.nu-  if not (is-git-repo) { return }
--
completions.nu:def "nu-complete git subcommands" [] {
completions.nu-  if not (is-git-repo) { return }
```