### PR TITLE
FEATURE: complete `ghq` API and rename to `gm`

### DIFF
--- a/mod.nu
+++ b/mod.nu
@@ -38,12 +38,12 @@ export def "gm grab" [
     --host: string = "github.com" # the host to grab the repo from.
     --ssh (-p): bool              # use ssh instead of https.
     --bare (-b): bool             # clone as *bare* repo (specific to worktrees).
-    --update (-u): bool
-    --shallow (-s): bool
-    --branch: bool
-    --no-recursive: bool
-    --look: bool
-    --silent: bool
+    --update (-u): bool           # not supported
+    --shallow (-s): bool          # not supported
+    --branch: bool                # not supported
+    --no-recursive: bool          # not supported
+    --look: bool                  # not supported
+    --silent: bool                # not supported
     --vcs (-v): bool              # not supported
 ] {
     # TODO: implement `--update` option
@@ -89,10 +89,11 @@ export def "gm grab" [
     }
 }
 
+# list locally-cloned repositories
 export def "gm list repos" [
-    query?: string
-    --exact (-e): bool
-    --full-path (-p): bool
+    query?: string          # return only repositories matching the query
+    --exact (-e): bool      # force the match to be exact, i.e. the query equals to project, user/project or host/user/project
+    --full-path (-p): bool  # return the full paths instead of path relative to the `gm` root
 ] {
     let root = (root_dir)
     let repos = (
@@ -124,6 +125,7 @@ export def "gm list repos" [
     } else {}
 }
 
+# print the root of the repositories
 export def "gm root" [
     --all (-a): bool  # not supported
 ] {
@@ -134,6 +136,7 @@ export def "gm root" [
     root_dir
 }
 
+# create a new repository
 export def "gm create" [
     repository: string
     --vcs (-v): bool  # not supported

--- a/mod.nu
+++ b/mod.nu
@@ -26,6 +26,43 @@ export def-env "gm grab select" [] {
     cd $repo
 }
 
+# parse-project <repository URL> -> record<host: string, user: string, project: string>
+# parse-project <host>/<user>/<project> -> record<host: string, user: string, project: string>
+# parse-project <user>/<project> -> record<user: string, project: string>
+# parse-project <project> -> record<project: string>
+def parse-project [
+    project: string  # <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
+] {
+    let project = (
+        $project
+        | str replace '.git$' ''
+        | str replace '^http://' ''
+        | str replace '^https://' ''
+        | str replace '^ssh://' ''
+        | str replace '^git@' ''
+        | str replace --all ':' '/'
+        | str replace --all '\/+' '/'
+        | str trim -c '/'
+    )
+
+    let hup = ($project | parse "{host}/{user}/{project}")
+    if not ($hup | is-empty) {
+        return ($hup | into record)
+    }
+
+    let up = ($project | parse "{user}/{project}")
+    if not ($up | is-empty) {
+        return ($up | into record)
+    }
+
+    {project: $project}
+}
+
+def default-project [] {
+    default (git config --global user.name) user
+    | default "github.com" host
+}
+
 # TODO: add support for other hosts than github
 # TODO: better worktree support
 
@@ -147,4 +184,78 @@ export def "gm create" [
 
     # TODO: implement `gm create`
     log warning "COMING SOON"
+}
+
+# run the tests with
+# ```nu
+# use mod.nu; mod tests
+# ```
+#
+#[cfg(test)]
+export def tests [] {
+    use std "assert equal"
+    use std ["log info" "log debug"]
+
+    #[test]
+    def parse-project-test [] {
+        log debug "testing empty input"
+        assert equal (parse-project "") {project: ""}
+
+        # normal parsing
+        log debug "testing some normal parsing"
+        let expected = {host: "host", user: "user", project: "project"}
+        assert equal (parse-project "/host/user/project") $expected
+        assert equal (parse-project "host/user/project/") $expected
+        assert equal (parse-project "host//user/project") $expected
+        assert equal (parse-project "host/user/project") $expected
+        assert equal (parse-project "host/user/project.git") $expected
+        assert equal (parse-project "http://host/user/project") $expected
+        assert equal (parse-project "https://host/user/project") $expected
+        assert equal (parse-project "ssh://host/user/project") $expected
+        assert equal (parse-project "git@host:user/project.git") $expected
+
+        # subgroups?
+        log debug "testing parsing of subgroups"
+        assert equal (parse-project "host/user/group/subgroup/subsubgroup/project") {
+            host: "host", user: "user", project: "group/subgroup/subsubgroup/project"
+        }
+
+        # default values...
+        log debug "testing missing fields"
+        assert equal (parse-project "user/project") {user: "user", project: "project"}
+        assert equal (parse-project "project") {project: "project"}
+
+        # ... with subgroups?
+        # we cannot parse these properly, that will throw a runtime HTTP error
+        log debug "testing imperfect subgroups"
+        assert equal (parse-project "user/group/subgroup/subsubgroup/project") {
+            host: "user", user: "group", project: "subgroup/subsubgroup/project"
+        }
+        assert equal (parse-project "group/subgroup/subsubgroup/project") {
+            host: "group", user: "subgroup", project: "subsubgroup/project"
+        }
+
+        log debug "testing invalid project name"
+        assert equal (parse-project "git#host:user/project.git") {
+            host: "git#host", user: "user", project: "project"
+        }
+    }
+
+    def default-project-test-template [] {
+        assert equal ($in | default-project | columns | sort) ["host" "project" "user"]
+    }
+
+    #[test]
+    def default-project-test [] {
+        for project in [
+            {project: "foo"}
+            {project: "foo", user: "bar"}
+            {project: "foo", user: "bar", host: "baz"}
+        ] {
+            $project | default-project-test-template
+        }
+    }
+
+    parse-project-test
+    default-project-test
 }

--- a/mod.nu
+++ b/mod.nu
@@ -1,3 +1,5 @@
+use std ['log debug', 'log warning']
+
 def root_dir [] {
     $env.GIT_REPOS_HOME? | default ($nu.home-path | path join "dev")
 }
@@ -34,9 +36,44 @@ export def "gm grab" [
     owner: string                 # the name of the owner of the repo.
     repo: string                  # the name of the repo to grab.
     --host: string = "github.com" # the host to grab the repo from.
-    --ssh (-s): bool              # use ssh instead of https.
+    --ssh (-p): bool              # use ssh instead of https.
     --bare (-b): bool             # clone as *bare* repo (specific to worktrees).
+    --update (-u): bool
+    --shallow (-s): bool
+    --branch: bool
+    --no-recursive: bool
+    --look: bool
+    --silent: bool
+    --vcs (-v): bool              # not supported
 ] {
+    # TODO: implement `--update` option
+    if $update {
+        log warning "`--update` option for `gm grab` COMING SOON"
+    }
+    # TODO: implement `--shallow` option
+    if $shallow {
+        log warning "`--shallow` option for `gm grab` COMING SOON"
+    }
+    # TODO: implement `--branch` option
+    if $branch {
+        log warning "`--branch` option for `gm grab` COMING SOON"
+    }
+    # TODO: implement `--look` option
+    if $look {
+        log warning "`--look` option for `gm grab` COMING SOON"
+    }
+    # TODO: implement `--silent` option
+    if $silent {
+        log warning "`--silent` option for `gm grab` COMING SOON"
+    }
+    # TODO: implement `--no-recursive` option
+    if $no_recursive {
+        log warning "`--no-recursive` option for `gm grab` COMING SOON"
+    }
+    if $vcs {
+        log debug "`--vcs` option is NOT SUPPORTED in `gm grab`"
+    }
+
     let url = (if $ssh {
         $"git@($host):($owner)/($repo).git"
     } else {
@@ -50,4 +87,61 @@ export def "gm grab" [
     } else {
         git clone --recurse-submodules $url $local
     }
+}
+
+export def "gm list repos" [
+    query?: string
+    --exact (-e): bool
+    --full-path (-p): bool
+] {
+    let root = (root_dir)
+    let repos = (
+        ls ($root | path join "**" "*" ".git")
+        | get name
+        | path parse
+        | get parent
+        | str replace $root ""
+        | str trim -l -c (char path_sep)
+        | parse "{host}/{user}/{project}"
+        | insert user-project {|it| [$it.user $it.project] | path join}
+        | insert host-user-project {|it| [$it.host $it.user $it.project] | path join}
+    )
+
+    let repos = ($repos | if $query != null {
+        if $exact {
+            where {|it| (
+                ($it.project == $query) or
+                ($it.user-project == $query) or
+                ($it.host-user-project == $query)
+            )}
+        } else {
+            find $query
+        }
+    } else {})
+
+    $repos | get host-user-project | if $full_path {
+        each {|repo| $root | path join $repo}
+    } else {}
+}
+
+export def "gm root" [
+    --all (-a): bool  # not supported
+] {
+    if $all {
+        log debug "`--all` option is NOT SUPPORTED in `gm root`"
+    }
+
+    root_dir
+}
+
+export def "gm create" [
+    repository: string
+    --vcs (-v): bool  # not supported
+] {
+    if $vcs {
+        log debug "`--vcs` option is NOT SUPPORTED in `gm create`"
+    }
+
+    # TODO: implement `gm create`
+    log warning "COMING SOON"
 }

--- a/mod.nu
+++ b/mod.nu
@@ -12,12 +12,12 @@ def lsi [path: string = "."] {(
     | get 1 | str trim    # hack to suppress the errors
 )}
 
-export def-env "git ungrab" [] {
+export def-env "gm ungrab" [] {
     # TODO: ungrab should move to a trash folder!
     ls -s (root_dir) | gum choose
 }
 
-export def-env "git grab select" [] {
+export def-env "gm grab select" [] {
     let owner = (lsi (root_dir))
     let repo = (lsi $owner)
 
@@ -30,7 +30,7 @@ export def-env "git grab select" [] {
 # Clone a repository into a standard location
 #
 # This place is organised by domain and path.
-export def "git grab" [
+export def "gm grab" [
     owner: string                 # the name of the owner of the repo.
     repo: string                  # the name of the repo to grab.
     --host: string = "github.com" # the host to grab the repo from.

--- a/mod.nu
+++ b/mod.nu
@@ -70,9 +70,7 @@ def default-project [] {
 #
 # This place is organised by domain and path.
 export def "gm grab" [
-    owner: string                 # the name of the owner of the repo.
-    repo: string                  # the name of the repo to grab.
-    --host: string = "github.com" # the host to grab the repo from.
+    project: string               # <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
     --ssh (-p): bool              # use ssh instead of https.
     --bare (-b): bool             # clone as *bare* repo (specific to worktrees).
     --update (-u): bool           # not supported
@@ -111,13 +109,19 @@ export def "gm grab" [
         log debug "`--vcs` option is NOT SUPPORTED in `gm grab`"
     }
 
+    let project = (
+        parse-project $project
+        | default-project
+        | update project { str replace --all '\/' '-'}
+    )
+
     let url = (if $ssh {
-        $"git@($host):($owner)/($repo).git"
+        $"git@($project.host):($project.user)/($project.project).git"
     } else {
-        $"https://($host)/($owner)/($repo).git"
+        $"https://($project.host)/($project.user)/($project.project).git"
     })
 
-    let local = (root_dir | path join $host $owner $repo)
+    let local = (root_dir | path join $project.host $project.user $project.project)
 
     if $bare {
         git clone --bare --recurse-submodules $url $local

--- a/mod.nu
+++ b/mod.nu
@@ -135,14 +135,14 @@ export def "gm list repos" [
     query?: string          # return only repositories matching the query
     --exact (-e): bool      # force the match to be exact, i.e. the query equals to project, user/project or host/user/project
     --full-path (-p): bool  # return the full paths instead of path relative to the `gm` root
+    --recursive: bool
 ] {
     let root = (root_dir)
     let repos = (
-        ls ($root | path join "**" "*" ".git")
+        ls ($root | if $recursive { path join "**" "*" ".git" } else { path join "*" "*" "*"})
         | get name
-        | path parse
-        | get parent
-        | str replace $root ""
+        | str replace $"^($root)" ""
+        | str replace $".git$" ""
         | str trim -l -c (char path_sep)
         | parse "{host}/{user}/{project}"
         | insert user-project {|it| [$it.user $it.project] | path join}


### PR DESCRIPTION
should close #3.

this PR
- renames the commands from `git ...` to `gm ...`
- implements all the API of `ghq`
  - `gm list repos` and `gm root` are complete i think
  - `--all` and `--vcs` are there for legacy but not used
  - other options are there but not implemented
  - in all cases, if a non-implemented or non-supported option is used, a log warning or debug statement will be used