### PR TITLE
FEATURE: follow the *XDG base directory* specifications

### DIFF
--- a/mod.nu
+++ b/mod.nu
@@ -1,5 +1,9 @@
 def root_dir [] {
-    $env.GIT_REPOS_HOME? | default ($nu.home-path | path join "dev")
+    $env.GIT_REPOS_HOME? | default (
+        $env.XDG_DATA_HOME?
+        | default ($env.HOME | path join ".local" "share")
+        | path join "nu-git-manager"
+    )
 }
 
 # TODO: support cancel


### PR DESCRIPTION
as in the name :wink: 

the root of the repository store is computed as follows:
- using the user-defined `GIT_REPOS_HOME` environment variable
- `XDG_DATA_HOME/.local/share/nu-git-manager/` if `GIT_REPOS_HOME` is undefined
- `HOME/.local/share/nu-git-manager/` if `XDG_DATA_HOME` is undefined