### PR TITLE
FEATURE: add `check-gh-logged-in` before running `gh`

### DIFF
--- a/sugar/gh.nu
+++ b/sugar/gh.nu
@@ -1,3 +1,12 @@
+def check-gh-logged-in [] {
+    let out = (do -i { gh auth status } | complete)
+    if $out.exit_code != 0 {
+        error make --unspanned {
+            msg: $out.stderr
+        }
+    }
+}
+
 def "nu-complete list-repos" [context: string] {
     let user = ($context | str replace 'gh\s*pr\s*open\s*' "" | split row " " | get 0)
 
@@ -76,6 +85,8 @@ def unpack-pages [] {
 def pull [
   endpoint: string
 ] {
+    check-gh-logged-in
+
     gh api --paginate $endpoint  # get all the raw data
     | unpack-pages               # split the pages into a single one
     | from json                  # convert to JSON internally
@@ -141,6 +152,8 @@ export def "me pr" [
     number?: int
     --open-in-browser (-o): bool
 ] {
+    check-gh-logged-in
+
     let repo = (
         gh repo view --json nameWithOwner
         | from json


### PR DESCRIPTION
related to #19 

this PR adds a new `check-gh-logged-in` command to `gh`.
this command checks `gh auth status`, which will return a non-zero exit code and an error message when not logged in. Then, `check-gh-logged-in` will return a nice `nushell` unspanned error.

the error is
```
Error: 
  × You are not logged into any GitHub hosts. Run gh auth login to
  │ authenticate.
  │ 
```
otherwise, when already logged in, nothing is shown at all and the scripts work as expected

> **Note**
> the slow down is quite small and hard to see, i think it's ok to have such a better error handling :relieved: 