### PR TITLE
FEATURE: use a true module-based structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ in your `config.nu` you can add the following to load `nu-git-manager` modules:
 # config.nu
 
 # load the main `gm` module
-use nu-git-manager/mod.nu *
+use nu-git-manager/gm
 
 # the following are non-essential modules
 use nu-git-manager/sugar/git.nu                # load `git` tool extensions

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 A collection of `nushell` tools to manage `git` repositories.
 
 ## installation
+> **Warning**
+> `gm` requires the use of `nushell` after [nushell/nushell#9066]
+> e.g. from any branch / commit based on [`a2a346e39`].
+>
+> alternatively, you can use any revision of `nu-git-manager`
+> before #21.
+
 one way to install `nu-git-manager` right now is the following
 - clone the repo to a location you want it to be
 ```nu
@@ -54,3 +61,6 @@ help modules gist
 # or
 gist
 ```
+
+[nushell/nushell#9066]: https://github.com/nushell/nushell/pull/9066
+[`a2a346e39`]: https://github.com/nushell/nushell/commit/a2a346e39c53e386b97d8d7f9a05ed58298e8789

--- a/gm/mod.nu
+++ b/gm/mod.nu
@@ -121,9 +121,12 @@ export def list [
     --exact (-e): bool      # force the match to be exact, i.e. the query equals to project, user/project or host/user/project
     --full-path (-p): bool  # return the full paths instead of path relative to the `gm` root
     --recursive: bool       # perform a recursive search of all `.git/` directories
-] {
-    list repos $query --exact $exact --full-path $full_path --recursive $recursive
-}
+] {(
+    list repos $query
+        --exact $exact
+        --full-path $full_path
+        --recursive $recursive
+)}
 
 # print the root of the repositories
 export def root [

--- a/gm/mod.nu
+++ b/gm/mod.nu
@@ -18,7 +18,7 @@ def pick-repo [
 }
 
 # fuzzy-jump to any repository managed by `gm`
-export def-env "gm goto" [
+export def-env goto [
     query?: string  # a search query to narrow down the list of choices
 ] {
     let choice = (pick-repo
@@ -33,7 +33,7 @@ export def-env "gm goto" [
 }
 
 # fuzzy-delete any repository managed by `gm`
-export def "gm remove" [
+export def remove [
     query?: string      # a search query to narrow down the list of choices
     --force (-f): bool  # do not ask for comfirmation when deleting a repository
 ] {
@@ -96,7 +96,7 @@ def default-project [] {
 # Clone a repository into a standard location
 #
 # This place is organised by domain and path.
-export def "gm grab" [
+export def grab [
     project: string               # <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
     --ssh (-p): bool              # use ssh instead of https.
     --bare (-b): bool             # clone as *bare* repo (specific to worktrees).
@@ -163,7 +163,7 @@ export def "gm grab" [
 # - host
 # - user
 # - project
-export def "gm list repos" [
+export def "list repos" [
     query?: string          # return only repositories matching the query
     --exact (-e): bool      # force the match to be exact, i.e. the query equals to project, user/project or host/user/project
     --full-path (-p): bool  # return the full paths instead of path relative to the `gm` root
@@ -199,7 +199,7 @@ export def "gm list repos" [
 }
 
 # print the root of the repositories
-export def "gm root" [
+export def root [
     --all (-a): bool  # not supported
 ] {
     if $all {
@@ -210,7 +210,7 @@ export def "gm root" [
 }
 
 # create a new repository
-export def "gm create" [
+export def create [
     repository: string  # <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
     --vcs (-v): bool    # not supported
 ] {
@@ -223,7 +223,7 @@ export def "gm create" [
 }
 
 # the `nu-[g]it-[m]anager`, a WIP to manage any `git` repo in a centralized store, with sugar on top
-export def gm [] { help gm }
+export def main [] { help gm }
 
 # run the tests with
 # ```nu

--- a/gm/mod.nu
+++ b/gm/mod.nu
@@ -1,12 +1,9 @@
 use std ['log debug', 'log warning']
-
-def root_dir [] {
-    $env.GIT_REPOS_HOME? | default (
-        $env.XDG_DATA_HOME?
-        | default ($env.HOME | path join ".local" "share")
-        | path join "nu-git-manager"
-    )
-}
+use utils [
+    "root_dir"
+    "parse-project"
+    "default-project"
+]
 
 def pick-repo [
     prompt: string
@@ -51,43 +48,6 @@ export def remove [
     } else {
         rm --trash --verbose --recursive $repo --interactive
     }
-}
-
-# parse-project <repository URL> -> record<host: string, user: string, project: string>
-# parse-project <host>/<user>/<project> -> record<host: string, user: string, project: string>
-# parse-project <user>/<project> -> record<user: string, project: string>
-# parse-project <project> -> record<project: string>
-def parse-project [
-    project: string  # <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
-] {
-    let project = (
-        $project
-        | str replace '.git$' ''
-        | str replace '^http://' ''
-        | str replace '^https://' ''
-        | str replace '^ssh://' ''
-        | str replace '^git@' ''
-        | str replace --all ':' '/'
-        | str replace --all '\/+' '/'
-        | str trim -c '/'
-    )
-
-    let hup = ($project | parse "{host}/{user}/{project}")
-    if not ($hup | is-empty) {
-        return ($hup | into record)
-    }
-
-    let up = ($project | parse "{user}/{project}")
-    if not ($up | is-empty) {
-        return ($up | into record)
-    }
-
-    {project: $project}
-}
-
-def default-project [] {
-    default (git config --global user.name) user
-    | default "github.com" host
 }
 
 # TODO: add support for other hosts than github
@@ -224,77 +184,3 @@ export def create [
 
 # the `nu-[g]it-[m]anager`, a WIP to manage any `git` repo in a centralized store, with sugar on top
 export def main [] { help gm }
-
-# run the tests with
-# ```nu
-# use mod.nu; mod tests
-# ```
-#
-#[cfg(test)]
-export def tests [] {
-    use std "assert equal"
-    use std ["log info" "log debug"]
-
-    #[test]
-    def parse-project-test [] {
-        log debug "testing empty input"
-        assert equal (parse-project "") {project: ""}
-
-        # normal parsing
-        log debug "testing some normal parsing"
-        let expected = {host: "host", user: "user", project: "project"}
-        assert equal (parse-project "/host/user/project") $expected
-        assert equal (parse-project "host/user/project/") $expected
-        assert equal (parse-project "host//user/project") $expected
-        assert equal (parse-project "host/user/project") $expected
-        assert equal (parse-project "host/user/project.git") $expected
-        assert equal (parse-project "http://host/user/project") $expected
-        assert equal (parse-project "https://host/user/project") $expected
-        assert equal (parse-project "ssh://host/user/project") $expected
-        assert equal (parse-project "git@host:user/project.git") $expected
-
-        # subgroups?
-        log debug "testing parsing of subgroups"
-        assert equal (parse-project "host/user/group/subgroup/subsubgroup/project") {
-            host: "host", user: "user", project: "group/subgroup/subsubgroup/project"
-        }
-
-        # default values...
-        log debug "testing missing fields"
-        assert equal (parse-project "user/project") {user: "user", project: "project"}
-        assert equal (parse-project "project") {project: "project"}
-
-        # ... with subgroups?
-        # we cannot parse these properly, that will throw a runtime HTTP error
-        log debug "testing imperfect subgroups"
-        assert equal (parse-project "user/group/subgroup/subsubgroup/project") {
-            host: "user", user: "group", project: "subgroup/subsubgroup/project"
-        }
-        assert equal (parse-project "group/subgroup/subsubgroup/project") {
-            host: "group", user: "subgroup", project: "subsubgroup/project"
-        }
-
-        log debug "testing invalid project name"
-        assert equal (parse-project "git#host:user/project.git") {
-            host: "git#host", user: "user", project: "project"
-        }
-    }
-
-    def default-project-test-template [] {
-        assert equal ($in | default-project | columns | sort) ["host" "project" "user"]
-    }
-
-    #[test]
-    def default-project-test [] {
-        for project in [
-            {project: "foo"}
-            {project: "foo", user: "bar"}
-            {project: "foo", user: "bar", host: "baz"}
-        ] {
-            $project | default-project-test-template
-        }
-    }
-
-    parse-project-test
-    default-project-test
-}

--- a/gm/mod.nu
+++ b/gm/mod.nu
@@ -1,8 +1,8 @@
 use std ['log debug', 'log warning']
 use utils [
-    "root_dir"
-    "parse-project"
-    "default-project"
+    "get root dir"
+    "parse project"
+    "default project"
 ]
 
 def pick-repo [
@@ -26,7 +26,7 @@ export def-env goto [
         return
     }
 
-    cd (root_dir | path join $choice)
+    cd (get root dir | path join $choice)
 }
 
 # fuzzy-delete any repository managed by `gm`
@@ -42,7 +42,7 @@ export def remove [
         return
     }
 
-    let repo = (root_dir | path join $choice)
+    let repo = (get root dir | path join $choice)
     if $force {
         rm --trash --verbose --recursive $repo
     } else {
@@ -97,8 +97,8 @@ export def grab [
     }
 
     let project = (
-        parse-project $project
-        | default-project
+        parse project $project
+        | default project
         | update project { str replace --all '\/' '-'}
     )
 
@@ -108,7 +108,7 @@ export def grab [
         $"https://($project.host)/($project.user)/($project.project).git"
     })
 
-    let local = (root_dir | path join $project.host $project.user $project.project)
+    let local = (get root dir | path join $project.host $project.user $project.project)
 
     if $bare {
         git clone --bare --recurse-submodules $url $local
@@ -129,7 +129,7 @@ export def "list repos" [
     --full-path (-p): bool  # return the full paths instead of path relative to the `gm` root
     --recursive: bool       # perform a recursive search of all `.git/` directories
 ] {
-    let root = (root_dir)
+    let root = (get root dir)
     let repos = (
         ls ($root | if $recursive { path join "**" "*" ".git" } else { path join "*" "*" "*"})
         | get name
@@ -166,7 +166,7 @@ export def root [
         log debug "`--all` option is NOT SUPPORTED in `gm root`"
     }
 
-    root_dir
+    get root dir
 }
 
 # create a new repository

--- a/gm/utils.nu
+++ b/gm/utils.nu
@@ -1,0 +1,110 @@
+export def root_dir [] {
+    $env.GIT_REPOS_HOME? | default (
+        $env.XDG_DATA_HOME?
+        | default ($env.HOME | path join ".local" "share")
+        | path join "nu-git-manager"
+    )
+}
+
+# parse-project <repository URL> -> record<host: string, user: string, project: string>
+# parse-project <host>/<user>/<project> -> record<host: string, user: string, project: string>
+# parse-project <user>/<project> -> record<user: string, project: string>
+# parse-project <project> -> record<project: string>
+export def parse-project [
+    project: string  # <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
+] {
+    let project = (
+        $project
+        | str replace '.git$' ''
+        | str replace '^http://' ''
+        | str replace '^https://' ''
+        | str replace '^ssh://' ''
+        | str replace '^git@' ''
+        | str replace --all ':' '/'
+        | str replace --all '\/+' '/'
+        | str trim -c '/'
+    )
+
+    let hup = ($project | parse "{host}/{user}/{project}")
+    if not ($hup | is-empty) {
+        return ($hup | into record)
+    }
+
+    let up = ($project | parse "{user}/{project}")
+    if not ($up | is-empty) {
+        return ($up | into record)
+    }
+
+    {project: $project}
+}
+
+export def default-project [] {
+    default (git config --global user.name) user
+    | default "github.com" host
+}
+
+#[cfg(test)]
+module tests {
+    use std "assert equal"
+    use std ["log info" "log debug"]
+
+    #[test]
+    export def parse-project-test [] {
+        log debug "testing empty input"
+        assert equal (parse-project "") {project: ""}
+
+        # normal parsing
+        log debug "testing some normal parsing"
+        let expected = {host: "host", user: "user", project: "project"}
+        assert equal (parse-project "/host/user/project") $expected
+        assert equal (parse-project "host/user/project/") $expected
+        assert equal (parse-project "host//user/project") $expected
+        assert equal (parse-project "host/user/project") $expected
+        assert equal (parse-project "host/user/project.git") $expected
+        assert equal (parse-project "http://host/user/project") $expected
+        assert equal (parse-project "https://host/user/project") $expected
+        assert equal (parse-project "ssh://host/user/project") $expected
+        assert equal (parse-project "git@host:user/project.git") $expected
+
+        # subgroups?
+        log debug "testing parsing of subgroups"
+        assert equal (parse-project "host/user/group/subgroup/subsubgroup/project") {
+            host: "host", user: "user", project: "group/subgroup/subsubgroup/project"
+        }
+
+        # default values...
+        log debug "testing missing fields"
+        assert equal (parse-project "user/project") {user: "user", project: "project"}
+        assert equal (parse-project "project") {project: "project"}
+
+        # ... with subgroups?
+        # we cannot parse these properly, that will throw a runtime HTTP error
+        log debug "testing imperfect subgroups"
+        assert equal (parse-project "user/group/subgroup/subsubgroup/project") {
+            host: "user", user: "group", project: "subgroup/subsubgroup/project"
+        }
+        assert equal (parse-project "group/subgroup/subsubgroup/project") {
+            host: "group", user: "subgroup", project: "subsubgroup/project"
+        }
+
+        log debug "testing invalid project name"
+        assert equal (parse-project "git#host:user/project.git") {
+            host: "git#host", user: "user", project: "project"
+        }
+    }
+
+    def default-project-test-template [] {
+        assert equal ($in | default-project | columns | sort) ["host" "project" "user"]
+    }
+
+    #[test]
+    export def default-project-test [] {
+        for project in [
+            {project: "foo"}
+            {project: "foo", user: "bar"}
+            {project: "foo", user: "bar", host: "baz"}
+        ] {
+            $project | default-project-test-template
+        }
+    }
+}

--- a/gm/utils.nu
+++ b/gm/utils.nu
@@ -1,4 +1,4 @@
-export def root_dir [] {
+export def "get root dir" [] {
     $env.GIT_REPOS_HOME? | default (
         $env.XDG_DATA_HOME?
         | default ($env.HOME | path join ".local" "share")
@@ -10,7 +10,7 @@ export def root_dir [] {
 # parse-project <host>/<user>/<project> -> record<host: string, user: string, project: string>
 # parse-project <user>/<project> -> record<user: string, project: string>
 # parse-project <project> -> record<project: string>
-export def parse-project [
+export def "parse project" [
     project: string  # <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
 ] {
     let project = (
@@ -38,7 +38,7 @@ export def parse-project [
     {project: $project}
 }
 
-export def default-project [] {
+export def "default project" [] {
     default (git config --global user.name) user
     | default "github.com" host
 }


### PR DESCRIPTION
related to nushell/nushell#9066

this PR
- uses the new module structure from nushell/nushell#9066
  - `gm` is now used with a simpler `use path/to/gm` without mentioning `mod.nu` ever, which is an implementation detail
- moves the tool commands to `utils.nu`
- uses a `gm utils tests` module to hold the tests (tests are exported by convention)

> **Warning**
> the API of `gm` changes a bit for namespace reasons and to make the API a bit simpler
> - `gm list repos` is now `gm list`
>
> tests can't be run anymore as-is :thinking: 