### PR TITLE
add a CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"
 
       - name: Install Nupm from Source
-        run: git clone https://github.com/nushell/nupm "${{ env.NUPM }}/nupm"
+        run: git clone https://github.com/nushell/nupm "${{ env.NUPM }}"
 
       - name: Show Nushell Version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,20 @@ jobs:
             echo "ARCH=x86_64-linux-gnu-full" >> $GITHUB_ENV
             echo "EXT=tar.gz" >> $GITHUB_ENV
             echo "NU_BIN=nu" >> $GITHUB_ENV
+            echo "NUPM=$HOME/nupm" >> $GITHUB_ENV
           elif [ "${{ runner.os }}" = "Windows" ]; then
             echo "ARCH=x86_64-pc-windows-msvc" >> $GITHUB_ENV
             echo "EXT=zip" >> $GITHUB_ENV
             echo "NU_BIN=nu.exe" >> $GITHUB_ENV
+            # NOTE: for some reason, `$HOME` gives an incorrect path on Windows, e.g. it looks like
+            # `/c/Users/runneradmin` where it should really be `c:\Users\runneradmin`: this commands
+            # changes the `/` into `\` and replaces the first part of the path with "x:\"
+            echo "NUPM=$(echo $HOME | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')/nupm" >> $GITHUB_ENV
           elif [ "${{ runner.os }}" = "macOS" ]; then
             echo "ARCH=x86_64-apple-darwin" >> $GITHUB_ENV
             echo "EXT=tar.gz" >> $GITHUB_ENV
             echo "NU_BIN=nu" >> $GITHUB_ENV
+            echo "NUPM=$HOME/nupm" >> $GITHUB_ENV
           fi
 
       - name: Install Nushell from Nightly
@@ -59,7 +65,7 @@ jobs:
           cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"
 
       - name: Install Nupm from Source
-        run: git clone https://github.com/nushell/nupm $HOME/nupm
+        run: git clone https://github.com/nushell/nupm "${{ env.NUPM }}/nupm"
 
       - name: Show Nushell Version
         run: |
@@ -67,4 +73,4 @@ jobs:
 
       - name: Run the tests
         run: |
-          "$HOME/${{ env.NU_BIN }}" --commands "use $HOME/nupm/nupm/; nupm test"
+          "$HOME/${{ env.NU_BIN }}" --commands "use ${{ env.NUPM }}/nupm/; nupm test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+name: continuous-integration
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-20.04]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set platform-specific variables
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            echo "ARCH=x86_64-linux-gnu-full" >> $GITHUB_ENV
+            echo "EXT=tar.gz" >> $GITHUB_ENV
+            echo "NU_BIN=nu" >> $GITHUB_ENV
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            echo "ARCH=x86_64-pc-windows-msvc" >> $GITHUB_ENV
+            echo "EXT=zip" >> $GITHUB_ENV
+            echo "NU_BIN=nu.exe" >> $GITHUB_ENV
+          elif [ "${{ runner.os }}" = "macOS" ]; then
+            echo "ARCH=x86_64-apple-darwin" >> $GITHUB_ENV
+            echo "EXT=tar.gz" >> $GITHUB_ENV
+            echo "NU_BIN=nu" >> $GITHUB_ENV
+          fi
+
+      - name: Install Nushell from Nightly
+        run: |
+          tarball=$(\
+            curl -L https://api.github.com/repos/nushell/nightly/releases \
+                | jq 'sort_by(.published_at) | reverse | .[0].assets'\
+                | jq '.[] | select(.name | test("${{ env.ARCH }}.${{ env.EXT }}")) | {name, browser_download_url}'\
+            )
+          name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.${{ env.EXT }}$//')
+          url=$(echo $tarball | jq '.browser_download_url' | tr -d '"')
+
+          curl -fLo $name $url
+
+          if [ "${{ env.EXT }}" = "tar.gz" ]; then
+            tar xvf $name --directory /tmp
+          elif [ "${{ env.EXT }}" = "zip" ]; then
+            unzip $name -d "/tmp/$name"
+          fi
+          cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"
+
+      - name: Install Nupm from Source
+        run: git clone https://github.com/nushell/nupm $HOME/nupm
+
+      - name: Show Nushell Version
+        run: |
+          "$HOME/${{ env.NU_BIN }}" --commands "version"
+
+      - name: Run the tests
+        run: |
+          "$HOME/${{ env.NU_BIN }}" --commands "use $HOME/nupm/nupm/; nupm test"


### PR DESCRIPTION
related to
- https://github.com/nushell/nupm/pull/30
- https://github.com/amtoine/nu-git-manager/issues/24

wait for these to land 
- https://github.com/nushell/nupm/pull/30

## description
this PR
- adds an empty `tests/mod.nu` module so that `nupm test` can work
- adds a CI greatly inspired by https://github.com/nushell/nupm/pull/30
  - does not need the `CWD` trick for Windows (:pray:)
  - pulls down Nushell from nightly builds
  - clones Nupm
  - shows the version of Nushell
  - runs the tests