### PR TITLE
implement cache based listing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  NU_LOG_LEVEL: DEBUG
+
 jobs:
   tests:
     strategy:

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 A collection of Nushell tools to manage `git` repositories.
 
 # Table of content
-- [*what is `nu-git-manager`*](#bulb-what-is-nu-git-manager-toc)
-- [*requirements*](#link-requirements-toc)
-- [*installation*](#recycle-installation-toc)
-- [*usage*](#gear-usage-toc)
-    - [*getting help*](#pray-getting-help-toc)
-- [*some ideas of advanced (?) usage*](#exclamation-some-ideas-of-advanced--usage-toc)
+- [nu-git-manager](#nu-git-manager)
+- [Table of content](#table-of-content)
+  - [:bulb: what is `nu-git-manager` \[toc\]](#bulb-what-is-nu-git-manager-toc)
+  - [:link: requirements \[toc\]](#link-requirements-toc)
+  - [:recycle: installation \[toc\]](#recycle-installation-toc)
+  - [:gear: usage \[toc\]](#gear-usage-toc)
+    - [:pray: getting help \[toc\]](#pray-getting-help-toc)
+  - [:exclamation: some ideas of advanced (?) usage \[toc\]](#exclamation-some-ideas-of-advanced--usage-toc)
 
 ## :bulb: what is `nu-git-manager` [[toc](#table-of-content)]
 like [`ghq`](https://github.com/x-motemen/ghq), `nu-git-manager` aims at being a fully-featured
@@ -45,7 +47,7 @@ in your `config.nu` you can add the following to load `nu-git-manager` modules:
 # config.nu
 
 # load the main `gm` command
-use nu-git-manager [gm, "gm clone", "gm cache", "gm list", "gm root", "gm remove"]
+use nu-git-manager [gm, "gm clone", "gm list", "gm root", "gm remove"]
 
 # the following are non-essential modules
 use nu-git-manager sugar git                # augmnet Git with custom commands

--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ it provides two main modules:
 - `gh` (optional) 2.29.0 (used by `sugar gh`)
     - with Pacman and `pacman -S community/github-cli`
     - with Nix and `nix run nixpkgs#gh`
-- `find` 4.9.0
-    - with Pacman and `pacman -S core/findutils`
-    - with Nix and `nix run nixpkgs#findutils`
 
 ## :recycle: installation [[toc](#table-of-content)]
 - install [Nupm] (**recommended**) by following the [Nupm instructions]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ in your `config.nu` you can add the following to load `nu-git-manager` modules:
 # config.nu
 
 # load the main `gm` command
-use nu-git-manager [gm, "gm clone", "gm list", "gm root", "gm remove"]
+use nu-git-manager [gm, "gm clone", "gm cache", "gm list", "gm root", "gm remove"]
 
 # the following are non-essential modules
 use nu-git-manager sugar git                # augmnet Git with custom commands

--- a/nu-git-manager/fs/path.nu
+++ b/nu-git-manager/fs/path.nu
@@ -1,4 +1,4 @@
 # sanitize a Windows path
 export def "path sanitize" []: path -> path {
-    str replace --all '\' '/'
+    str replace --regex '^.:' '' | str replace --all '\' '/'
 }

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -20,7 +20,8 @@ export def list-repos-in-store []: nothing -> list<path> {
         return []
     }
 
-    # FIXME: glob does not work with Windows very well
+    # FIXME: glob does not work very well with Windows and absolute paths: the easy fix is to `cd`
+    # first and then perform the globbing
     # related to https://github.com/nushell/nushell/issues/7125
     cd (get-repo-store-path)
     let heads: list<string> = glob "**/HEAD" --not [

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -32,7 +32,7 @@ export def list-repos-in-store []: nothing -> list<path> {
         ]
     # NOTE: we need to keep the trailing `/` here to avoid telling that `foo.bar` is a duplicate of
     # `foo`, because `foo/` is not contained in `foo.bar/`
-    let repos = $heads | str replace --regex '(.git/)?HEAD$' ''
+    let repos = $heads | each { path sanitize } | str replace --regex '(.git/)?HEAD$' ''
 
     let sorted = $repos | sort
     let pairs = $sorted | range 1.. | zip ($sorted | range ..(-2))
@@ -40,6 +40,5 @@ export def list-repos-in-store []: nothing -> list<path> {
         | filter {|it| not ($it.0 | str starts-with $it.1)}
         | each { get 0 }
         | prepend $sorted.0
-        | each { path sanitize }
         | str trim --right --char "/"
 }

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -17,6 +17,7 @@ export def get-repo-store-cache-path []: nothing -> path {
 
 export def list-repos-in-store []: nothing -> list<path> {
     if not (get-repo-store-path | path exists) {
+        log debug $"the store does not exist: `(get-repo-store-path)`"
         return []
     }
 

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -19,11 +19,14 @@ export def list-repos-in-store []: nothing -> list<path> {
         return []
     }
 
-    let res: list<string> = glob ($env.GIT_REPOS_HOME | path join "**/HEAD") --not [
+    let heads: list<string> = glob ($env.GIT_REPOS_HOME | path join "**/HEAD") --not [
             **/.git/**/refs/remotes/**/HEAD,
             **/.git/modules/**/HEAD,
             **/logs/HEAD
         ]
+    let repos = $heads | str replace --regex '/(.git/)?HEAD$' ''
 
-    $res | str replace --regex '/(.git/)?HEAD$' ''
+    let sorted = $repos | sort
+    let pairs = $sorted | range 1.. | zip ($sorted | range ..(-2))
+    $pairs | filter {|it| not ($it.0 | str starts-with $it.1)} | each { get 0 } | prepend $sorted.0
 }

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -24,9 +24,15 @@ export def list-repos-in-store []: nothing -> list<path> {
             **/.git/modules/**/HEAD,
             **/logs/HEAD
         ]
-    let repos = $heads | str replace --regex '/(.git/)?HEAD$' ''
+    # NOTE: we need to keep the trailing `/` here to avoid telling that `foo.bar` is a duplicate of
+    # `foo`, because `foo/` is not contained in `foo.bar/`
+    let repos = $heads | str replace --regex '(.git/)?HEAD$' ''
 
     let sorted = $repos | sort
     let pairs = $sorted | range 1.. | zip ($sorted | range ..(-2))
-    $pairs | filter {|it| not ($it.0 | str starts-with $it.1)} | each { get 0 } | prepend $sorted.0
+    $pairs
+        | filter {|it| not ($it.0 | str starts-with $it.1)}
+        | each { get 0 }
+        | prepend $sorted.0
+        | str trim --right --char (char path_sep)
 }

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -15,6 +15,17 @@ export def get-repo-store-cache-path []: nothing -> path {
         | path sanitize
 }
 
+export def check-cache-file [cache_file: path]: nothing -> nothing {
+    if not ($cache_file | path exists) {
+        error make --unspanned {
+            msg: (
+                $"(ansi red_bold)cache_not_found(ansi reset):\n"
+              + $"please run `(ansi default_dimmed)gm cache --update(ansi reset)` to create the cache"
+            )
+        }
+    }
+}
+
 export def list-repos-in-store []: nothing -> list<path> {
     if not (get-repo-store-path | path exists) {
         log debug $"the store does not exist: `(get-repo-store-path)`"

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -20,7 +20,10 @@ export def list-repos-in-store []: nothing -> list<path> {
         return []
     }
 
-    let heads: list<string> = glob ($env.GIT_REPOS_HOME | path join "**/HEAD") --not [
+    # FIXME: glob does not work with Windows very well
+    # related to https://github.com/nushell/nushell/issues/7125
+    cd $env.GIT_REPOS_HOME
+    let heads: list<string> = glob "**/HEAD" --not [
             **/.git/**/refs/remotes/**/HEAD,
             **/.git/modules/**/HEAD,
             **/logs/HEAD

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -22,7 +22,7 @@ export def list-repos-in-store []: nothing -> list<path> {
 
     # FIXME: glob does not work with Windows very well
     # related to https://github.com/nushell/nushell/issues/7125
-    cd $env.GIT_REPOS_HOME
+    cd (get-repo-store-path)
     let heads: list<string> = glob "**/HEAD" --not [
             **/.git/**/refs/remotes/**/HEAD,
             **/.git/modules/**/HEAD,

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -40,5 +40,6 @@ export def list-repos-in-store []: nothing -> list<path> {
         | filter {|it| not ($it.0 | str starts-with $it.1)}
         | each { get 0 }
         | prepend $sorted.0
-        | str trim --right --char (char path_sep)
+        | each { path sanitize }
+        | str trim --right --char "/"
 }

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -12,6 +12,7 @@ export def get-repo-store-cache-path []: nothing -> path {
         | default ($nu.home-path | path join ".cache")
         | path join "nu-git-manager/cache.nuon"
         | path expand
+        | path sanitize
 }
 
 export def list-repos-in-store []: nothing -> list<path> {

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -70,6 +70,10 @@ export def "gm clone" [
 
     git -C $local_path remote set-url $remote $urls.fetch
     git -C $local_path remote set-url $remote --push $urls.push
+
+    gm list --update
+
+    null
 }
 
 # list all the local repositories in your local store
@@ -153,7 +157,7 @@ export def "gm remove" [
     --fuzzy # remove after fuzzy-finding the repo(s) to clean
 ]: nothing -> nothing {
     let root = get-repo-store-path
-    let choices = list-repos-in-store
+    let choices = gm list
         | each {
             str replace $root '' | str trim --left --char (char path_sep)
         }
@@ -194,6 +198,8 @@ export def "gm remove" [
         "no" => { log info $"user chose to (ansi green_bold)keep(ansi reset) (ansi yellow)($repo_to_remove)(ansi reset)" },
         "yes" => { rm --recursive --force --verbose ($root | path join $repo_to_remove) },
     }
+
+    gm list --update
 
     null
 }

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -141,6 +141,20 @@ export def "gm root" []: nothing -> path {
     get-repo-store-path
 }
 
+# get the path to the cache of the local store of repositories managed by `nu-git-manager`
+#
+# `nu-git-manager` will look for a cache in the following places, in order:
+# - `$env.XDG_CACHE_HOME | path join "nu-git-manager/cache.nuon"
+# - `~/.cache/nu-git-manager/cache.nuon`
+#
+# # Example
+#     a contrived example, assuming you are in `~`
+#     > XDG_CACHE_HOME=foo gm root
+#     ~/foo/nu-git-manager/cache.nuon
+export def "gm cache" []: nothing -> path {
+    get-repo-store-cache-path
+}
+
 # remove one of the repositories from your local store
 #
 # # Examples

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -121,7 +121,7 @@ export def "gm list" [
         $repos
     } else {
         $repos | each {
-            str replace (get-repo-store-path) '' | str trim --left --char (char path_sep)
+            str replace (get-repo-store-path) '' | str trim --left --char "/"
         }
     }
 }
@@ -173,7 +173,7 @@ export def "gm remove" [
     let root = get-repo-store-path
     let choices = gm list
         | each {
-            str replace $root '' | str trim --left --char (char path_sep)
+            str replace $root '' | str trim --left --char "/"
         }
         | find $pattern
 

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -98,7 +98,6 @@ export def "gm list" [
     --full-path # show the full path instead of only the "owner + group + repo" name
 ]: nothing -> list<path> {
     let cache_file = get-repo-store-cache-path
-
     check-cache-file $cache_file
 
     let repos = open $cache_file

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -101,7 +101,7 @@ export def get-repo-cache [] {
 
     for case in $cases {
         let actual = with-env $case.env { get-repo-store-cache-path }
-        assert equal $actual ($case.expected | path expand)
+        assert equal $actual ($case.expected | path expand | path sanitize)
     }
 }
 

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -114,19 +114,19 @@ export def list-all-repos-in-store [] {
     mkdir $BASE
 
     let store = [
-        [bare,  store,  path];
+        [is_bare, in_store, path];
 
-        [false, true,  "a/normal/"],
-        [true,  true,  "a/bare/"],
-        [false, true,  "b/c/d/normal/"],
-        [true,  true,  "b/c/d/bare/"],
-        [false, false, "a/normal/b/nested/"],
-        [false, false, "a/normal/.git/modules/foo/"],
-        [false, true,  "a/normal.but.more.complex/"],
+        [false,   true,     "a/normal/"],
+        [true,    true,     "a/bare/"],
+        [false,   true,     "b/c/d/normal/"],
+        [true,    true,     "b/c/d/bare/"],
+        [false,   false,    "a/normal/b/nested/"],
+        [false,   false,    "a/normal/.git/modules/foo/"],
+        [false,   true,     "a/normal.but.more.complex/"],
     ]
 
     for repo in $store {
-        if $repo.bare {
+        if $repo.is_bare {
             git init --bare ($BASE | path join $repo.path)
         } else {
             git init ($BASE | path join $repo.path)
@@ -137,7 +137,7 @@ export def list-all-repos-in-store [] {
     let actual = with-env {GIT_REPOS_HOME: $BASE} { list-repos-in-store } | each {
         str replace $BASE '' | str trim --char (char path_sep)
     }
-    let expected = $store | where store | get path | each {
+    let expected = $store | where in_store | get path | each {
         # NOTE: `list-repos-in-store` does not add `/` at the end of the paths
         str trim --right --char (char path_sep)
     }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -1,7 +1,9 @@
 use std assert
 
 use ../nu-git-manager/git/url.nu [parse-git-url, get-fetch-push-urls]
-use ../nu-git-manager/fs/store.nu [get-repo-store-path, list-repos-in-store]
+use ../nu-git-manager/fs/store.nu [
+    get-repo-store-path, get-repo-store-cache-path, list-repos-in-store
+]
 use ../nu-git-manager/fs/path.nu "path sanitize"
 
 export def path-sanitization [] {
@@ -86,6 +88,20 @@ export def get-store-root [] {
     for case in $cases {
         let actual = with-env $case.env { get-repo-store-path }
         assert equal $actual ($case.expected | path expand | path sanitize)
+    }
+}
+
+export def get-repo-cache [] {
+    let cases = [
+        [env,                       expected];
+
+        [{XDG_CACHE_HOME: null},    "~/.cache/nu-git-manager/cache.nuon"],
+        [{XDG_CACHE_HOME: "~/xdg"}, "~/xdg/nu-git-manager/cache.nuon"],
+    ]
+
+    for case in $cases {
+        let actual = with-env $case.env { get-repo-store-cache-path }
+        assert equal $actual ($case.expected | path expand)
     }
 }
 

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -106,6 +106,8 @@ export def get-repo-cache [] {
 }
 
 export def list-all-repos-in-store [] {
+    # NOTE: `$BASE` is a constant, hence the capitalized name, but `path sanitize` is not a
+    # parse-time command
     let BASE = (
         $nu.temp-path | path join "nu-git-manager/tests/list-all-repos-in-store" | path sanitize
     )

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -1,7 +1,7 @@
 use std assert
 
 use ../nu-git-manager/git/url.nu [parse-git-url, get-fetch-push-urls]
-use ../nu-git-manager/fs/store.nu get-repo-store-path
+use ../nu-git-manager/fs/store.nu [get-repo-store-path, list-repos-in-store]
 use ../nu-git-manager/fs/path.nu "path sanitize"
 
 export def path-sanitization [] {
@@ -87,4 +87,47 @@ export def get-store-root [] {
         let actual = with-env $case.env { get-repo-store-path }
         assert equal $actual ($case.expected | path expand | path sanitize)
     }
+}
+
+export def list-all-repos-in-store [] {
+    const BASE = ($nu.temp-path | path join "nu-git-manager/tests/list-all-repos-in-store")
+
+    if ($BASE | path exists) {
+        rm --recursive --verbose --force $BASE
+    }
+    mkdir $BASE
+
+    let store = [
+        [bare,  store,  path];
+
+        [false, true,  "a/normal/"],
+        [true,  true,  "a/bare/"],
+        [false, true,  "b/c/d/normal/"],
+        [true,  true,  "b/c/d/bare/"],
+        [false, false, "a/normal/b/nested/"],
+        [false, false, "a/normal/.git/modules/foo/"],
+    ]
+
+    for repo in $store {
+        if $repo.bare {
+            git init --bare ($BASE | path join $repo.path)
+        } else {
+            git init ($BASE | path join $repo.path)
+        }
+    }
+
+    # NOTE: remove the path to BASE so that the test output is easy to read
+    let actual = with-env {GIT_REPOS_HOME: $BASE} { list-repos-in-store } | each {
+        str replace $BASE '' | str trim --char (char path_sep)
+    }
+    let expected = $store | where store | get path | each {
+        # NOTE: `list-repos-in-store` does not add `/` at the end of the paths
+        str trim --right --char (char path_sep)
+    }
+
+    # NOTE: need to sort the result to make sure the order of the `git init` does not influence the
+    # results of the test
+    assert equal ($actual | sort) ($expected | sort)
+
+    rm --recursive --verbose --force $BASE
 }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -135,11 +135,11 @@ export def list-all-repos-in-store [] {
 
     # NOTE: remove the path to BASE so that the test output is easy to read
     let actual = with-env {GIT_REPOS_HOME: $BASE} { list-repos-in-store } | each {
-        str replace $BASE '' | str trim --char (char path_sep)
+        str replace $BASE '' | str trim --left --char "/"
     }
     let expected = $store | where in_store | get path | each {
         # NOTE: `list-repos-in-store` does not add `/` at the end of the paths
-        str trim --right --char (char path_sep)
+        str trim --right --char "/"
     }
 
     # NOTE: need to sort the result to make sure the order of the `git init` does not influence the

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -122,6 +122,7 @@ export def list-all-repos-in-store [] {
         [true,  true,  "b/c/d/bare/"],
         [false, false, "a/normal/b/nested/"],
         [false, false, "a/normal/.git/modules/foo/"],
+        [false, true,  "a/normal.but.more.complex/"],
     ]
 
     for repo in $store {

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -106,7 +106,9 @@ export def get-repo-cache [] {
 }
 
 export def list-all-repos-in-store [] {
-    const BASE = ($nu.temp-path | path join "nu-git-manager/tests/list-all-repos-in-store")
+    let BASE = (
+        $nu.temp-path | path join "nu-git-manager/tests/list-all-repos-in-store" | path sanitize
+    )
 
     if ($BASE | path exists) {
         rm --recursive --verbose --force $BASE


### PR DESCRIPTION
## description
#26 had three major flaws, `list-repos-in-store`
- did depend on GNU `find` on Linux and MacOS
- did use  `glob` on Windows, which is slow
- did not catch any *bare* repo and did list nested directories, such as Git modules

this PR tries to solve these at once
- will use `glob` only for all the OSes and removed the dependency on `find`
- will use a cache to store the state of the repos currently managed by `gm`
- the *globbing* pattern and post-treatment will both catch the *bare* repos and remove nested duplicates

### new features
- `gm cache` is a new command that gives the cache currently used
   - the cache will follow the XDG Base Directory specification and will default to `~/.local/share/nu-git-manager/cache.nuon`
   - it has a `--update` switch to force a full update of the cache: this might take some time
- `gm list` will simply `open` the cache and dump it's content as a list: this will be super fast
- `gm clone` and `gm remove` will update the cache in a super fast way, without `list-repos-in-store`
    - `gm clone` will just append the new path to the cache
    - `gm remove` will just remove the removed path from the cache
    - otherwise, if the user changes the store manually, they will have to run `gm cache --update` manually to fix `gm list`'s output
- `gm list` will be used in other commands instead of `list-repos-in-store` to use the cache

> **Note**
> paths will be more sanitized by removing the drive, e.g. `D:`, from the beginning of Windows paths

> **Note**
> `list-repos-in-store` will throw a DEBUG line when the store does not exist.
> the CI will set `NU_LOG_LEVEL` to `DEBUG` to see that in the CI.

> **Note**
> this PR makes sure all paths are sanitized and removes mention to `path_sep` from the `gm` module

### details on the changes
with this PR, `list-repos-in-store` will
- use `glob`
- search for any occurence of a `HEAD` file
- remove invalid matches, e.g. multiple `HEAD`s that are stored in multiple places in `.git/` directories
- remove nested duplicates from the list, e.g. Git submodules

## tests
this PR adds two tests
- `get-repo-cache` to make sure the cache is properly setup
- `list-all-repos-in-store` to make sure `list-repos-in-store` can list all repos, *bare* ones included, without nested duplicates, in a fake store