### PR TITLE
use Git as an explicit external command

### DIFF
--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -63,13 +63,13 @@ export def "gm clone" [
     let urls = get-fetch-push-urls $repository $fetch $push $ssh
 
     if $bare {
-        git clone $urls.fetch $local_path --origin $remote --bare
+        ^git clone $urls.fetch $local_path --origin $remote --bare
     } else {
-        git clone $urls.fetch $local_path --origin $remote
+        ^git clone $urls.fetch $local_path --origin $remote
     }
 
-    git -C $local_path remote set-url $remote $urls.fetch
-    git -C $local_path remote set-url $remote --push $urls.push
+    ^git -C $local_path remote set-url $remote $urls.fetch
+    ^git -C $local_path remote set-url $remote --push $urls.push
 }
 
 # list all the local repositories in your local store


### PR DESCRIPTION
as it's already done in `list-repos-in-store` with the external `find` command, to avoid conflict with built-ins, i propose to use `^git` in the main module of `nu-git-manager` :yum: 