### PR TITLE
add `gm status` command

### DIFF
--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -20,7 +20,7 @@ export def check-cache-file [cache_file: path]: nothing -> nothing {
         error make --unspanned {
             msg: (
                 $"(ansi red_bold)cache_not_found(ansi reset):\n"
-              + $"please run `(ansi default_dimmed)gm cache --update(ansi reset)` to create the cache"
+              + $"please run `(ansi default_dimmed)gm update-cache(ansi reset)` to create the cache"
             )
         }
     }

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -167,8 +167,13 @@ export def "gm status" []: nothing -> record<root: record<path: path, exists: bo
     let root = get-repo-store-path
     let cache = get-repo-store-cache-path
 
-    let missing = open $cache | where ($it | path type) != "dir"
     let cache_exists = ($cache | path type) == "file"
+
+    let missing = if $cache_exists {
+        open $cache | where ($it | path type) != "dir"
+    } else {
+        null
+    }
 
     {
         root: {


### PR DESCRIPTION
## description
this PR refactors a bit the subcommands of `gm`
- merge `gm root` and `gm cache` into `gm status`
- rename `gm cache --update` to `gm update-cache`

apart from that it's mostly moving the docstrings around to `gm` and rewriting docs for `gm update-cache` and `gm status` :yum: 