### PR TITLE
read cache from env

### DIFF
--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -8,9 +8,12 @@ export def get-repo-store-path []: nothing -> path {
 }
 
 export def get-repo-store-cache-path []: nothing -> path {
-    $env.XDG_CACHE_HOME?
-        | default ($nu.home-path | path join ".cache")
-        | path join "nu-git-manager/cache.nuon"
+    $env.GIT_REPOS_CACHE?
+        | default (
+            $env.XDG_CACHE_HOME?
+                | default ($nu.home-path | path join ".cache")
+                | path join "nu-git-manager/cache.nuon"
+        )
         | path expand
         | path sanitize
 }

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -22,6 +22,7 @@ def "nu-complete git-protocols" []: nothing -> table<value: string, description:
 # - `~/.local/share/repos`
 #
 # `nu-git-manager` will look for a cache in the following places, in order:
+# - `$env.GIT_REPOS_CACHE`
 # - `$env.XDG_CACHE_HOME | path join "nu-git-manager/cache.nuon"
 # - `~/.cache/nu-git-manager/cache.nuon`
 #

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -96,7 +96,13 @@ export def "gm clone" [
     check-cache-file $cache_file
 
     print --no-newline "updating cache... "
-    open $cache_file | append $local_path | uniq | sort | save --force $cache_file
+    open --raw $cache_file
+        | from nuon
+        | append $local_path
+        | uniq
+        | sort
+        | to nuon
+        | save --force $cache_file
     print "done"
 
     null
@@ -119,7 +125,7 @@ export def "gm list" [
     let cache_file = get-repo-store-cache-path
     check-cache-file $cache_file
 
-    let repos = open $cache_file
+    let repos = open --raw $cache_file | from nuon
     if $full_path {
         $repos
     } else {
@@ -171,7 +177,7 @@ export def "gm status" []: nothing -> record<root: record<path: path, exists: bo
     let cache_exists = ($cache | path type) == "file"
 
     let missing = if $cache_exists {
-        open $cache | where ($it | path type) != "dir"
+        open --raw $cache | from nuon | where ($it | path type) != "dir"
     } else {
         null
     }
@@ -201,7 +207,10 @@ export def "gm update-cache" []: nothing -> nothing {
     mkdir ($cache_file | path dirname)
 
     print --no-newline "updating cache... "
-    list-repos-in-store | save --force $cache_file
+    let foo = list-repos-in-store
+    print ($foo | describe)
+    print $foo
+    $foo | to nuon | save --force $cache_file
     print "done"
 
     null
@@ -272,7 +281,12 @@ export def "gm remove" [
     check-cache-file $cache_file
 
     print --no-newline "updating cache... "
-    open $cache_file | where $it != ($root | path join $repo_to_remove) | save --force $cache_file
+    open --raw $cache_file
+        | from nuon
+        | where $it != ($root
+        | path join $repo_to_remove)
+        | to nuon
+        | save --force $cache_file
     print "done"
 
     null

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -93,10 +93,12 @@ export def get-store-root [] {
 
 export def get-repo-cache [] {
     let cases = [
-        [env,                       expected];
+        [env,                                                      expected];
 
-        [{XDG_CACHE_HOME: null},    "~/.cache/nu-git-manager/cache.nuon"],
-        [{XDG_CACHE_HOME: "~/xdg"}, "~/xdg/nu-git-manager/cache.nuon"],
+        [{GIT_REPOS_CACHE: null,         XDG_CACHE_HOME: null},    "~/.cache/nu-git-manager/cache.nuon"],
+        [{GIT_REPOS_CACHE: "~/my_cache", XDG_CACHE_HOME: null},    "~/my_cache"],
+        [{GIT_REPOS_CACHE: null,         XDG_CACHE_HOME: "~/xdg"}, "~/xdg/nu-git-manager/cache.nuon"],
+        [{GIT_REPOS_CACHE: "~/my_cache", XDG_CACHE_HOME: "~/xdg"}, "~/my_cache"],
     ]
 
     for case in $cases {


### PR DESCRIPTION
i was trying to help @stormasm with a strange bug of his and wanted to run something like the following to not use either my personal store nor my cache:
```nushell
with-env {
    GIT_REPOS_HOME: /tmp/repos,
    GIT_REPOS_CACHE: /tmp/repos.cache
} {
    gm update-cache
}
```

## description
this PR allows `gm` to read the cache location from `$env.GIT_REPOS_CACHE` before the XDG location and the default one.
this change happens in the `get-repo-store-cache-path` command and mirrors the behaviour from `get-repo-store-path`

> **Note**
> because the extension of the cache can now be anything, e.g. `.cache` in the snippet of this PR, `gm` can not assume that it's NUON directly
> - `open --raw $cache_file | from nuon` is used to open the content of the cache
> - `to nuon | save --force $cache_file` is used to dump the new cache to its file

## user-facing changes
```nushell
with-env {
    GIT_REPOS_HOME: /tmp/repos,
    GIT_REPOS_CACHE: /tmp/repos.cache
} {
    gm update-cache
}
```
can now be used to play with `gm` without messing with the real store of repos.