### PR TITLE
add a "bug report" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug Report
+description: Create a report to help us improve `nu-git-manager`
+labels: ["needs-triage"]
+body: 
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A succint explaination of the context where the bug appears.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: |
+        Steps to reproduce the behavior.
+
+        Make sure you run the following commands to use a blank store of repositories.
+
+        1. define the reproduction environment
+        ```nushell
+        const REPRO_ENV = {
+            GIT_REPOS_HOME: ($nu.temp-path | path join "repos/"),
+            GIT_REPOS_CACHE: ($nu.temp-path | path join "repos.cache"),
+        }
+        ```
+        2. clean the reproduction environment
+        ```nushell
+        with-env $REPRO_ENV {
+            gm status | select root.path cache.path | values | each {
+                if ($in | path exists) { rm --recursive --force --verbose $in }
+            }
+        }
+        ```
+        then run all the `gm` commands inside `with-env $REPRO_ENV { ... }`
+      placeholder: |
+        1. run `with-env $REPRO_ENV { gm clone https://github.com/amtoine/nu-git-manager }`
+        2. run `with-env $REPRO_ENV { gm update-cache }`
+        3. see the error
+        4. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: I expected nu-git-manager to...
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: "Please run `version | transpose key value | to md --pretty` and paste the output to show OS, features, etc."
+      placeholder: |
+        > version | transpose key value | to md --pretty
+        | key                | value                                                                                                                                                                   |
+        | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | version            | 0.40.0                                                                                                                                                                  |
+        | build_os           | linux-x86_64                                                                                                                                                            |
+        | rust_version       | rustc 1.56.1                                                                                                                                                            |
+        | cargo_version      | cargo 1.56.0                                                                                                                                                            |
+        | pkg_version        | 0.40.0                                                                                                                                                                  |
+        | build_time         | 1980-01-01 00:00:00 +00:00                                                                                                                                              |
+        | build_rust_channel | release                                                                                                                                                                 |
+        | features           | clipboard-cli, ctrlc, dataframe, default, rustyline, term, trash, uuid, which, zip                                                                                      |
+        | installed_plugins  | binaryview, chart bar, chart line, fetch, from bson, from sqlite, inc, match, post, ps, query json, s3, selector, start, sys, textview, to bson, to sqlite, tree, xpath |
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false
+


### PR DESCRIPTION
## description
i was trying to reproduce https://github.com/amtoine/nu-git-manager/issues/40 and set `$env.GIT_REPOS_HOME` and `$env.GIT_REPOS_CACHE` to empty and unused directories and files to not mess up with my repositories.

in this PR, i propose to add an issue template for bug reports.
this is greatly inspired by the [bug report of Nushell](https://github.com/nushell/nushell/issues/new?assignees=&labels=needs-triage&projects=&template=bug_report.yml).

the template will ask for
- a description
- steps to reproduce: here it will be asked to define a clean reproduction environment using the following commands
```nushell
const REPRO_ENV = {
    GIT_REPOS_HOME: ($nu.temp-path | path join "repos/"),
    GIT_REPOS_CACHE: ($nu.temp-path | path join "repos.cache"),
}
```
```nushell
with-env $REPRO_ENV {
    gm status | select root.path cache.path | values | each {
        if ($in | path exists) { rm --recursive --force --verbose $in }
    }
}
```
and then run all the `gm` commands in `with-env $REPRO_ENV { ... }`
- what was expected
- the configuration of Nushell used
- (optional) some additional information