### PR TITLE
extract cache logic out of `gm` itself

### DIFF
--- a/nu-git-manager/fs/cache.nu
+++ b/nu-git-manager/fs/cache.nu
@@ -51,3 +51,8 @@ export def open-cache [cache_file: path]: nothing -> list<path> {
 export def save-cache [cache_file: path]: list<path> -> nothing {
     to nuon | save --force $cache_file
 }
+
+export def make-cache [cache_file: path]: nothing -> nothing {
+    rm --recursive --force $cache_file
+    mkdir ($cache_file | path dirname)
+}

--- a/nu-git-manager/fs/cache.nu
+++ b/nu-git-manager/fs/cache.nu
@@ -21,3 +21,29 @@ export def check-cache-file [cache_file: path]: nothing -> nothing {
         }
     }
 }
+
+export def add-to-cache [cache_file: path, new_path: path]: nothing -> nothing {
+    print --no-newline "updating cache... "
+    open --raw $cache_file
+        | from nuon
+        | append $new_path
+        | uniq
+        | sort
+        | to nuon
+        | save --force $cache_file
+    print "done"
+}
+
+export def remove-from-cache [cache_file: path, old_path: path]: nothing -> nothing {
+    print --no-newline "updating cache... "
+    open --raw $cache_file
+        | from nuon
+        | where $it != $old_path
+        | to nuon
+        | save --force $cache_file
+    print "done"
+}
+
+export def open-cache [cache_file: path]: nothing -> list<path> {
+    open --raw $cache_file | from nuon
+}

--- a/nu-git-manager/fs/cache.nu
+++ b/nu-git-manager/fs/cache.nu
@@ -1,0 +1,23 @@
+use path.nu "path sanitize"
+
+export def get-repo-store-cache-path []: nothing -> path {
+    $env.GIT_REPOS_CACHE?
+        | default (
+            $env.XDG_CACHE_HOME?
+                | default ($nu.home-path | path join ".cache")
+                | path join "nu-git-manager/cache.nuon"
+        )
+        | path expand
+        | path sanitize
+}
+
+export def check-cache-file [cache_file: path]: nothing -> nothing {
+    if not ($cache_file | path exists) {
+        error make --unspanned {
+            msg: (
+                $"(ansi red_bold)cache_not_found(ansi reset):\n"
+              + $"please run `(ansi default_dimmed)gm update-cache(ansi reset)` to create the cache"
+            )
+        }
+    }
+}

--- a/nu-git-manager/fs/cache.nu
+++ b/nu-git-manager/fs/cache.nu
@@ -22,34 +22,24 @@ export def check-cache-file [cache_file: path]: nothing -> nothing {
     }
 }
 
-export def add-to-cache [cache_file: path, new_path: path]: nothing -> nothing {
-    print --no-newline "updating cache... "
-    open --raw $cache_file
-        | from nuon
-        | append $new_path
-        | uniq
-        | sort
-        | to nuon
-        | save --force $cache_file
-    print "done"
-}
-
-export def remove-from-cache [cache_file: path, old_path: path]: nothing -> nothing {
-    print --no-newline "updating cache... "
-    open --raw $cache_file
-        | from nuon
-        | where $it != $old_path
-        | to nuon
-        | save --force $cache_file
-    print "done"
-}
-
 export def open-cache [cache_file: path]: nothing -> list<path> {
     open --raw $cache_file | from nuon
 }
 
 export def save-cache [cache_file: path]: list<path> -> nothing {
     to nuon | save --force $cache_file
+}
+
+export def add-to-cache [cache_file: path, new_path: path]: nothing -> nothing {
+    print --no-newline "updating cache... "
+    open-cache $cache_file | append $new_path | uniq | sort | save-cache $cache_file
+    print "done"
+}
+
+export def remove-from-cache [cache_file: path, old_path: path]: nothing -> nothing {
+    print --no-newline "updating cache... "
+    open-cache $cache_file | where $it != $old_path | save-cache $cache_file
+    print "done"
 }
 
 export def make-cache [cache_file: path]: nothing -> nothing {

--- a/nu-git-manager/fs/cache.nu
+++ b/nu-git-manager/fs/cache.nu
@@ -47,3 +47,7 @@ export def remove-from-cache [cache_file: path, old_path: path]: nothing -> noth
 export def open-cache [cache_file: path]: nothing -> list<path> {
     open --raw $cache_file | from nuon
 }
+
+export def save-cache [cache_file: path]: list<path> -> nothing {
+    to nuon | save --force $cache_file
+}

--- a/nu-git-manager/fs/store.nu
+++ b/nu-git-manager/fs/store.nu
@@ -7,28 +7,6 @@ export def get-repo-store-path []: nothing -> path {
     ) | path expand | path sanitize
 }
 
-export def get-repo-store-cache-path []: nothing -> path {
-    $env.GIT_REPOS_CACHE?
-        | default (
-            $env.XDG_CACHE_HOME?
-                | default ($nu.home-path | path join ".cache")
-                | path join "nu-git-manager/cache.nuon"
-        )
-        | path expand
-        | path sanitize
-}
-
-export def check-cache-file [cache_file: path]: nothing -> nothing {
-    if not ($cache_file | path exists) {
-        error make --unspanned {
-            msg: (
-                $"(ansi red_bold)cache_not_found(ansi reset):\n"
-              + $"please run `(ansi default_dimmed)gm update-cache(ansi reset)` to create the cache"
-            )
-        }
-    }
-}
-
 export def list-repos-in-store []: nothing -> list<path> {
     if not (get-repo-store-path | path exists) {
         log debug $"the store does not exist: `(get-repo-store-path)`"

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -2,7 +2,8 @@ use std log
 
 use fs/store.nu [get-repo-store-path, list-repos-in-store]
 use fs/cache.nu [
-    get-repo-store-cache-path, check-cache-file, add-to-cache, remove-from-cache, open-cache
+    get-repo-store-cache-path, check-cache-file, add-to-cache, remove-from-cache, open-cache,
+    save-cache
 ]
 use git/url.nu [parse-git-url, get-fetch-push-urls]
 
@@ -201,7 +202,7 @@ export def "gm update-cache" []: nothing -> nothing {
     let foo = list-repos-in-store
     print ($foo | describe)
     print $foo
-    $foo | to nuon | save --force $cache_file
+    $foo | save-cache $cache_file
     print "done"
 
     null

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -199,7 +199,7 @@ export def "gm update-cache" []: nothing -> nothing {
     make-cache $cache_file
 
     print --no-newline "updating cache... "
-    list-repos-in-store | to nuon | save --force $cache_file
+    list-repos-in-store | save-cache $cache_file
     print "done"
 
     null

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -1,8 +1,7 @@
 use std log
 
-use fs/store.nu [
-    check-cache-file, get-repo-store-path, get-repo-store-cache-path, list-repos-in-store
-]
+use fs/store.nu [get-repo-store-path, list-repos-in-store]
+use fs/cache.nu [get-repo-store-cache-path, check-cache-file]
 use git/url.nu [parse-git-url, get-fetch-push-urls]
 
 def "nu-complete git-protocols" []: nothing -> table<value: string, description: string> {

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -3,7 +3,7 @@ use std log
 use fs/store.nu [get-repo-store-path, list-repos-in-store]
 use fs/cache.nu [
     get-repo-store-cache-path, check-cache-file, add-to-cache, remove-from-cache, open-cache,
-    save-cache
+    save-cache, make-cache
 ]
 use git/url.nu [parse-git-url, get-fetch-push-urls]
 
@@ -195,8 +195,7 @@ export def "gm status" []: nothing -> record<root: record<path: path, exists: bo
 #     > gm update-cache
 export def "gm update-cache" []: nothing -> nothing {
     let cache_file = get-repo-store-cache-path
-    rm --recursive --force $cache_file
-    mkdir ($cache_file | path dirname)
+    make-cache $cache_file
 
     print --no-newline "updating cache... "
     let foo = list-repos-in-store

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -1,9 +1,8 @@
 use std assert
 
 use ../nu-git-manager/git/url.nu [parse-git-url, get-fetch-push-urls]
-use ../nu-git-manager/fs/store.nu [
-    get-repo-store-path, get-repo-store-cache-path, list-repos-in-store
-]
+use ../nu-git-manager/fs/store.nu [get-repo-store-path, list-repos-in-store]
+use ../nu-git-manager/fs/cache.nu [get-repo-store-cache-path]
 use ../nu-git-manager/fs/path.nu "path sanitize"
 
 export def path-sanitization [] {

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -2,7 +2,10 @@ use std assert
 
 use ../nu-git-manager/git/url.nu [parse-git-url, get-fetch-push-urls]
 use ../nu-git-manager/fs/store.nu [get-repo-store-path, list-repos-in-store]
-use ../nu-git-manager/fs/cache.nu [get-repo-store-cache-path]
+use ../nu-git-manager/fs/cache.nu [
+    get-repo-store-cache-path, check-cache-file, add-to-cache, remove-from-cache, open-cache,
+    save-cache, make-cache
+]
 use ../nu-git-manager/fs/path.nu "path sanitize"
 
 export def path-sanitization [] {
@@ -152,4 +155,25 @@ export def list-all-repos-in-store [] {
     assert equal ($actual | sort) ($expected | sort)
 
     rm --recursive --verbose --force $BASE
+}
+
+export def cache-manipulation [] {
+    let CACHE = (
+        $nu.temp-path | path join "nu-git-manager/tests" (random uuid) | path sanitize
+    )
+    let CACHE_DIR = $CACHE | path dirname
+    if ($CACHE_DIR | path exists) {
+        rm --recursive --verbose --force $CACHE_DIR
+    }
+    mkdir $CACHE_DIR
+
+    # TODO: the real testing
+    # - check-cache-file
+    # - add-to-cache
+    # - remove-from-cache
+    # - open-cache
+    # - save-cache
+    # - make-cache
+
+    rm --recursive --verbose --force $CACHE_DIR
 }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -164,7 +164,13 @@ export def cache-manipulation [] {
     let CACHE_DIR = $CACHE | path dirname
 
     def "assert cache" [cache: list<string>]: nothing -> nothing {
-        assert equal (open-cache $CACHE) ($cache | path expand | each { path sanitize })
+        let actual = open-cache $CACHE | str replace (pwd) '' | str trim --left --char '/'
+        let expected = $cache
+            | path expand
+            | each { path sanitize }
+            | str replace (pwd) ''
+            | str trim --left --char '/'
+        assert equal $actual $expected
     }
 
     assert error { check-cache-file $CACHE }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -164,11 +164,13 @@ export def cache-manipulation [] {
     let CACHE_DIR = $CACHE | path dirname
 
     def "assert cache" [cache: list<string>]: nothing -> nothing {
-        let actual = open-cache $CACHE | str replace (pwd) '' | str trim --left --char '/'
+        let actual = open-cache $CACHE
+            | str replace (pwd | path sanitize) ''
+            | str trim --left --char '/'
         let expected = $cache
             | path expand
             | each { path sanitize }
-            | str replace (pwd) ''
+            | str replace (pwd | path sanitize) ''
             | str trim --left --char '/'
         assert equal $actual $expected
     }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -183,19 +183,19 @@ export def cache-manipulation [] {
     [] | save-cache $CACHE
     assert cache []
 
-    add-to-cache $CACHE "foo"
+    add-to-cache $CACHE ("foo" | path expand | path sanitize)
     assert cache ["foo"]
 
-    add-to-cache $CACHE "bar"
+    add-to-cache $CACHE ("bar" | path expand | path sanitize)
     assert cache ["bar", "foo"]
 
-    add-to-cache $CACHE "baz"
+    add-to-cache $CACHE ("baz" | path expand | path sanitize)
     assert cache ["bar", "baz", "foo"]
 
-    remove-from-cache $CACHE "bar"
+    remove-from-cache $CACHE ("bar" | path expand | path sanitize)
     assert cache ["baz", "foo"]
 
-    remove-from-cache $CACHE "brr"
+    remove-from-cache $CACHE ("brr" | path expand | path sanitize)
     assert cache ["baz", "foo"]
 
     rm --recursive --verbose --force $CACHE_DIR

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -162,18 +162,33 @@ export def cache-manipulation [] {
         $nu.temp-path | path join "nu-git-manager/tests" (random uuid) | path sanitize
     )
     let CACHE_DIR = $CACHE | path dirname
-    if ($CACHE_DIR | path exists) {
-        rm --recursive --verbose --force $CACHE_DIR
-    }
-    mkdir $CACHE_DIR
 
-    # TODO: the real testing
-    # - check-cache-file
-    # - add-to-cache
-    # - remove-from-cache
-    # - open-cache
-    # - save-cache
-    # - make-cache
+    def "assert cache" [cache: list<string>]: nothing -> nothing {
+        assert equal (open-cache $CACHE) ($cache | path expand | each { path sanitize })
+    }
+
+    assert error { check-cache-file $CACHE }
+
+    make-cache $CACHE
+    assert ($CACHE | path dirname | path exists)
+
+    [] | save-cache $CACHE
+    assert cache []
+
+    add-to-cache $CACHE "foo"
+    assert cache ["foo"]
+
+    add-to-cache $CACHE "bar"
+    assert cache ["bar", "foo"]
+
+    add-to-cache $CACHE "baz"
+    assert cache ["bar", "baz", "foo"]
+
+    remove-from-cache $CACHE "bar"
+    assert cache ["baz", "foo"]
+
+    remove-from-cache $CACHE "brr"
+    assert cache ["baz", "foo"]
 
     rm --recursive --verbose --force $CACHE_DIR
 }


### PR DESCRIPTION
as explained in https://github.com/amtoine/nu-git-manager/issues/24#issuecomment-1781547274, i encountered a cache bug when working on #39 => because the cache path can now be fully set by the user with `$env.GIT_REPOS_CACHE`, it does not have the `.nuon` extension in general and thus we cannot assume `open $env.GIT_REPOS_CACHE` to open the file as NUON data...

## description
in order to allow testing more of the internals of the `gm` commands, i propose in this PR to move the cache logic as much as possible from `gm` itself to a new internal `fs/cache.nu` module.

> **Important**
> this might sounds like *clean code*, e.g. where you put all the code in nested oneliners...
> i would argue it's not the goal of this PR and the fact that the resulting commands are quite small is simply because they are doing quite simple stuff!
> the goal here is to move the internal logic out of the public `gm` which exposes the main API to allow testing as much as possible without require to `gm clone` actual repositories or `gm remove` in an interactive manner :yum: 

### changelog
- move `get-repo-store-cache-path` and `check-cache-file` to a new `fs/cache.nu` module
- move most of the cache logic to commands in `fs/cache.nu`
- adds tests for the cache functionalities

## tests
a new `cache-manipulation` test in `tests/mod.nu`.