### PR TITLE
fix the config snippet in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ in your `config.nu` you can add the following to load `nu-git-manager` modules:
 # config.nu
 
 # load the main `gm` command
-use nu-git-manager [gm, "gm clone", "gm list", "gm root", "gm remove"]
+use nu-git-manager *
 
 # the following are non-essential modules
 use nu-git-manager sugar git                # augmnet Git with custom commands

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ nupm install --path --force nu-git-manager
 ## :gear: usage [[toc](#table-of-content)]
 in your `config.nu` you can add the following to load `nu-git-manager` modules:
 ```nu
-# config.nu
-
 # load the main `gm` command
 use nu-git-manager *
 


### PR DESCRIPTION
this PR uses
```nushell
use nu-git-manager *
```
instead of listing all the commands manually:
- there was already an error in the list
- this will help us maintain this snippet in the long term because `use ... *` always will work and you will most of the time want to import all the `gm` commands at once