### PR TITLE
add a starter toolkit to run the tests

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -1,0 +1,8 @@
+# run the tests of the `nu-git-manager` package
+#
+# > **Important**  
+# > the `toolkit test` command requires [Nupm](https://github.com/nushell/nupm) to be installed
+export def "test" [] {
+    use nupm
+    nupm test
+}

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -2,7 +2,14 @@
 #
 # > **Important**  
 # > the `toolkit test` command requires [Nupm](https://github.com/nushell/nupm) to be installed
-export def "test" [] {
+export def "test" [
+    --verbose # show the output of each tests
+] {
     use nupm
-    nupm test
+
+    if $verbose {
+        nupm test --show-stdout
+    } else {
+        nupm test
+    }
 }


### PR DESCRIPTION
this PR adds a very simple `toolkit.nu` to run the tests of `nu-git-manager` without worrying about `use nupm` and the exact commands to run:
```nushell
use toolkit.nu  # i use a hook for that
toolkit test
```