### PR TITLE
test `gm` commands end to end

### DIFF
--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -316,14 +316,13 @@ export def "gm remove" [
 
     if not $no_confirm {
         let prompt = $"are you (ansi defu)sure(ansi reset) you want to (ansi red_bold)remove(ansi reset) (ansi yellow)($repo_to_remove)(ansi reset)? "
-        match (["no", "yes"] | input list $prompt) {
-            "no" => {
-                log info $"user chose to (ansi green_bold)keep(ansi reset) (ansi yellow)($repo_to_remove)(ansi reset)"
-                return
-            },
-            "yes" => { rm --recursive --force --verbose ($root | path join $repo_to_remove) },
+        if (["no", "yes"] | input list $prompt) == "no" {
+            log info $"user chose to (ansi green_bold)keep(ansi reset) (ansi yellow)($repo_to_remove)(ansi reset)"
+            return
         }
     }
+
+    rm --recursive --force --verbose ($root | path join $repo_to_remove)
 
     let cache_file = get-repo-store-cache-path
     check-cache-file $cache_file

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -245,9 +245,13 @@ export def "gm update-cache" []: nothing -> nothing {
 #
 #     remove a precise repo by giving its full name, a name collision is unlikely
 #     > gm remove amtoine/nu-git-manager
+#
+#     remove a precise repo without confirmation
+#     > gm remove amtoine/nu-git-manager --no-confirm
 export def "gm remove" [
     pattern?: string # a pattern to restrict the choices
     --fuzzy # remove after fuzzy-finding the repo(s) to clean
+    --no-confirm # do not ask for confirmation: useful in scripts but requires a single match
 ]: nothing -> nothing {
     let root = get-repo-store-path
     let choices = gm list
@@ -271,6 +275,29 @@ export def "gm remove" [
         },
         1 => { $choices | first },
         _ => {
+            if $no_confirm {
+                if $pattern == null {
+                    error make --unspanned {
+                        msg: (
+                            $"(ansi red_bold)invalid_arguments_and_options(ansi reset):\n"
+                          + "no search pattern will match all projects and `--no-confirm` won't "
+                          + "remove multiple directories"
+                        )
+                    }
+                } else {
+                    throw-error {
+                        msg: "invalid_arguments_and_options"
+                        label: {
+                            text: (
+                                "this pattern is too broad, multiple repos won't be removed by "
+                              + "`--no-confirm`"
+                            )
+                            span: (metadata $pattern | get span)
+                        }
+                    }
+                }
+            }
+
             let prompt = $"please choose a repository to (ansi red)remove(ansi reset)"
             let choice = if $fuzzy {
                 $choices | input list --fuzzy $prompt
@@ -287,13 +314,15 @@ export def "gm remove" [
         },
     }
 
-    let prompt = $"are you (ansi defu)sure(ansi reset) you want to (ansi red_bold)remove(ansi reset) (ansi yellow)($repo_to_remove)(ansi reset)? "
-    match (["no", "yes"] | input list $prompt) {
-        "no" => {
-            log info $"user chose to (ansi green_bold)keep(ansi reset) (ansi yellow)($repo_to_remove)(ansi reset)"
-            return
-        },
-        "yes" => { rm --recursive --force --verbose ($root | path join $repo_to_remove) },
+    if not $no_confirm {
+        let prompt = $"are you (ansi defu)sure(ansi reset) you want to (ansi red_bold)remove(ansi reset) (ansi yellow)($repo_to_remove)(ansi reset)? "
+        match (["no", "yes"] | input list $prompt) {
+            "no" => {
+                log info $"user chose to (ansi green_bold)keep(ansi reset) (ansi yellow)($repo_to_remove)(ansi reset)"
+                return
+            },
+            "yes" => { rm --recursive --force --verbose ($root | path join $repo_to_remove) },
+        }
     }
 
     let cache_file = get-repo-store-cache-path

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -5,7 +5,7 @@ use ../src/nu-git-manager/ *
 
 def run-with-env [code: closure, --prepare-cache] {
     # NOTE: for the CI to run, the repos need to live inside `HOME`
-    let TEST_ENV_BASE = ($nu.home-path | path join ".local/share/nu-git-manager/tests" (random uuid))
+    let TEST_ENV_BASE = $nu.home-path | path join ".local/share/nu-git-manager/tests" (random uuid)
 
     let TEST_ENV = {
         GIT_REPOS_HOME: ($TEST_ENV_BASE | path join "repos"),

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -65,6 +65,16 @@ export def clone [] {
         # ```
         assert error { gm clone https://github.com/amtoine/nu-git-manager }
     }
+
+    run-with-env --prepare-cache {
+        gm clone https://github.com/amtoine/nu-git-manager
+
+        let repo = $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager"
+
+        let actual = git -C $repo rev-list HEAD | lines | last
+        let expected = "2ed2d875d80505d78423328c6b2a60522715fcdf"
+        assert equal $actual $expected
+    }
 }
 
 export def status [] {

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -40,8 +40,30 @@ export def cache-update [] {
 
 export def clone [] {
     run-with-env --prepare-cache {
+        # NOTE: full error
+        # ```
+        # Error:   × invalid_clone_depth
+        #    ╭─[entry #5:1:1]
+        #  1 │ gm clone https://github.com/amtoine/nu-git-manager --depth 0
+        #    ·                                                            ┬
+        #    ·                                                            ╰── clone depth should be strictly positive, found 0
+        #    ╰────
+        # ```
+        assert error { gm clone https://github.com/amtoine/nu-git-manager --depth 0 }
+
         gm clone https://github.com/amtoine/nu-git-manager --depth 1
         assert equal (gm list) ["github.com/amtoine/nu-git-manager"]
+
+        # NOTE: full error
+        # ```
+        # Error:   × repository_already_in_store
+        #    ╭─[entry #2:1:1]
+        #  1 │ gm clone https://github.com/amtoine/nu-git-manager
+        #    ·          ────────────────────┬────────────────────
+        #    ·                              ╰── this repository has already been cloned by gm
+        #    ╰────
+        # ```
+        assert error { gm clone https://github.com/amtoine/nu-git-manager }
     }
 }
 

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -98,13 +98,24 @@ export def clone-bare [] {
     }
 }
 
-export def clone-set-remote-name [] {
+export def clone-set-remote [] {
     run-with-env --prepare-cache {
-        gm clone https://github.com/amtoine/nu-git-manager --remote test-remote-name
+        let url = "https://github.com/amtoine/nu-git-manager"
+        gm clone $url --remote test-remote-name --fetch https --push ssh
 
         let repo = $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager"
 
-        assert equal (git -C $repo remote | lines) [test-remote-name]
+        let actual = git -C $repo remote --verbose
+            | lines
+            | parse --regex '(?<remote>[-_\w]+)\s+(?<url>.*) \((?<mode>\w+)\)'
+            | str trim
+        let expected = [
+            [remote, url, mode];
+
+            [test-remote-name, "https://github.com/amtoine/nu-git-manager", fetch],
+            [test-remote-name, "ssh://github.com/amtoine/nu-git-manager", push]
+        ]
+        assert equal $actual $expected
     }
 }
 

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -38,7 +38,7 @@ export def cache-update [] {
     }
 }
 
-export def clone [] {
+export def clone-invalid-depth [] {
     run-with-env --prepare-cache {
         # NOTE: full error
         # ```
@@ -50,10 +50,19 @@ export def clone [] {
         #    ╰────
         # ```
         assert error { gm clone https://github.com/amtoine/nu-git-manager --depth 0 }
+    }
+}
 
+export def clone-depth-1 [] {
+    run-with-env --prepare-cache {
         gm clone https://github.com/amtoine/nu-git-manager --depth 1
         assert equal (gm list) ["github.com/amtoine/nu-git-manager"]
+    }
+}
 
+export def clone-twice [] {
+    run-with-env --prepare-cache {
+        gm clone https://github.com/amtoine/nu-git-manager --depth 1
         # NOTE: full error
         # ```
         # Error:   × repository_already_in_store
@@ -65,7 +74,9 @@ export def clone [] {
         # ```
         assert error { gm clone https://github.com/amtoine/nu-git-manager }
     }
+}
 
+export def clone-full-repo [] {
     run-with-env --prepare-cache {
         gm clone https://github.com/amtoine/nu-git-manager
 

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -88,6 +88,26 @@ export def clone-full-repo [] {
     }
 }
 
+export def clone-bare [] {
+    run-with-env --prepare-cache {
+        gm clone https://github.com/amtoine/nu-git-manager --bare
+
+        let repo = $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager"
+
+        assert ($repo | path join "HEAD" | path exists)
+    }
+}
+
+export def clone-set-remote-name [] {
+    run-with-env --prepare-cache {
+        gm clone https://github.com/amtoine/nu-git-manager --remote test-remote-name
+
+        let repo = $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager"
+
+        assert equal (git -C $repo remote | lines) [test-remote-name]
+    }
+}
+
 export def status [] {
     run-with-env {
         let BASE_STATUS = {

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -4,15 +4,11 @@ use ../src/nu-git-manager/ *
 
 def run-with-env [code: closure, --prepare-cache] {
     # NOTE: for the CI to run, the repos need to live inside `HOME`
-    let TEST_ENV_BASE = ($nu.home-path | path join "nu-git-manager/tests" (random uuid))
+    let TEST_ENV_BASE = ($nu.home-path | path join ".local/share/nu-git-manager/tests" (random uuid))
 
     let TEST_ENV = {
         GIT_REPOS_HOME: ($TEST_ENV_BASE | path join "repos/"),
         GIT_REPOS_CACHE: ($TEST_ENV_BASE | path join "repos.cache"),
-    }
-
-    for target in ($TEST_ENV | values) {
-        if ($target | path exists) { rm --recursive --force --verbose $target }
     }
 
     if $prepare_cache {
@@ -20,6 +16,8 @@ def run-with-env [code: closure, --prepare-cache] {
     }
 
     with-env $TEST_ENV $code
+
+    rm --recursive --force --verbose $TEST_ENV_BASE
 }
 
 export def error-with-empty-store [] {

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -57,6 +57,7 @@ export def clone-invalid-depth [] {
 export def clone-depth-1 [] {
     run-with-env --prepare-cache {
         gm clone https://github.com/amtoine/nu-git-manager --depth 1
+        assert ($env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager" | path exists)
         assert equal (gm list) ["github.com/amtoine/nu-git-manager"]
     }
 }
@@ -210,9 +211,13 @@ export def remove [] {
         assert error { gm remove "github" --no-confirm }
 
         gm remove "github.com/amtoine/nu-git-manager" --no-confirm
+        assert not (
+            $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager" | path exists
+        )
         assert equal (gm list) ["github.com/nushell/nupm"]
 
         gm remove "github.com/nushell/nupm" --no-confirm
+        assert not ($env.GIT_REPOS_HOME | path join "github.com/nushell/nupm" | path exists)
         assert equal (gm list) []
     }
 }

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -22,6 +22,11 @@ def run-with-env [code: closure, --prepare-cache] {
 
 export def error-with-empty-store [] {
     run-with-env {
+        # NOTE: the full error:
+        # ```
+        # Error:   × cache_not_found:
+        #   │ please run `gm update-cache` to create the cache
+        # ```
         assert error { gm list }
     }
 }

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -164,3 +164,47 @@ export def status [] {
         assert equal $actual $expected
     }
 }
+
+export def remove [] {
+    run-with-env --prepare-cache {
+        gm clone https://github.com/amtoine/nu-git-manager --depth 1
+        gm clone https://github.com/nushell/nupm --depth 1
+
+        assert equal (gm list) ["github.com/amtoine/nu-git-manager", "github.com/nushell/nupm"]
+
+        # NOTE: true error
+        # ```
+        # Error:   × no_matching_repository
+        #    ╭─[entry #8:1:1]
+        #  1 │ gm remove "foo"
+        #    ·           ──┬──
+        #    ·             ╰── no repository matching this in .../repos
+        #    ╰────
+        # ```
+        assert error { gm remove "not-in-store" --no-confirm }
+
+        # NOTE: true error
+        # ```
+        # Error:   × invalid_arguments_and_options:
+        #   │ no search pattern will match all projects and `--no-confirm` won't remove multiple directories
+        # ```
+        assert error { gm remove --no-confirm }
+
+        # NOTE: true error
+        # ```
+        # Error:   × invalid_arguments_and_options
+        #    ╭─[entry #3:1:1]
+        #  1 │ gm remove github --no-confirm
+        #    ·           ───┬──
+        #    ·              ╰── this pattern is too broad, multiple repos won't be removed by `--no-confirm`
+        #    ╰────
+        # ```
+        assert error { gm remove "github" --no-confirm }
+
+        gm remove "github.com/amtoine/nu-git-manager" --no-confirm
+        assert equal (gm list) ["github.com/nushell/nupm"]
+
+        gm remove "github.com/nushell/nupm" --no-confirm
+        assert equal (gm list) []
+    }
+}

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -57,7 +57,12 @@ export def clone-invalid-depth [] {
 export def clone-depth-1 [] {
     run-with-env --prepare-cache {
         gm clone https://github.com/amtoine/nu-git-manager --depth 1
-        assert ($env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager" | path exists)
+        assert (
+            $env.GIT_REPOS_HOME
+                | path join "github.com/amtoine/nu-git-manager"
+                | path sanitize
+                | path exists
+        )
         assert equal (gm list) ["github.com/amtoine/nu-git-manager"]
     }
 }
@@ -212,12 +217,17 @@ export def remove [] {
 
         gm remove "github.com/amtoine/nu-git-manager" --no-confirm
         assert not (
-            $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager" | path exists
+            $env.GIT_REPOS_HOME
+            | path join "github.com/amtoine/nu-git-manager"
+            | path sanitize
+            | path exists
         )
         assert equal (gm list) ["github.com/nushell/nupm"]
 
         gm remove "github.com/nushell/nupm" --no-confirm
-        assert not ($env.GIT_REPOS_HOME | path join "github.com/nushell/nupm" | path exists)
+        assert not (
+            $env.GIT_REPOS_HOME | path join "github.com/nushell/nupm" | path sanitize | path exists
+        )
         assert equal (gm list) []
     }
 }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -8,8 +8,6 @@ use ../src/nu-git-manager/fs/cache.nu [
 ]
 use ../src/nu-git-manager/fs/path.nu "path sanitize"
 
-use ../src/nu-git-manager/ *
-
 export def path-sanitization [] {
     assert equal ('\foo\bar' | path sanitize) "/foo/bar"
 }
@@ -235,45 +233,5 @@ export def install-package [] {
         assert equal (ls ($env.NUPM_HOME | path join "modules") --short-names | get name) [nu-git-manager, nu-git-manager-sugar]
 
         rm --recursive --force --verbose $env.NUPM_HOME
-    }
-}
-
-def run-with-env [code: closure, --prepare-cache] {
-    # NOTE: for the CI to run, the repos need to live inside `HOME`
-    let TEST_ENV_BASE = ($nu.home-path | path join "nu-git-manager/tests" (random uuid))
-
-    let TEST_ENV = {
-        GIT_REPOS_HOME: ($TEST_ENV_BASE | path join "repos/"),
-        GIT_REPOS_CACHE: ($TEST_ENV_BASE | path join "repos.cache"),
-    }
-
-    for target in ($TEST_ENV | values) {
-        if ($target | path exists) { rm --recursive --force --verbose $target }
-    }
-
-    if $prepare_cache {
-        with-env $TEST_ENV { gm update-cache }
-    }
-
-    with-env $TEST_ENV $code
-}
-
-export def gm-error-with-empty-store [] {
-    run-with-env {
-        assert error { gm list }
-    }
-}
-
-export def gm-cache-update [] {
-    run-with-env {
-        gm update-cache
-        assert equal (gm list) []
-    }
-}
-
-export def gm-clone [] {
-    run-with-env --prepare-cache {
-        gm clone https://github.com/amtoine/nu-git-manager --depth 1
-        assert equal (gm list) ["github.com/amtoine/nu-git-manager"]
     }
 }


### PR DESCRIPTION
related to
- #24 

## description
in order to be able to test the `gm remove` command:
- add `--no-confirm` to `gm remove`

in a new `tests/gm.nu` test module, adds
- a `run-with-env` command to take care of the test environment wrapping and cleaning
- tests for
  - `gm list`
  - `gm update-cache`
  - `gm status`
  - `gm clone`
  - `gm remove` 
- the true expected errors next to `assert error` in NOTE, for when we'll be able to check the content of an error in Nushell :smirk: 