### PR TITLE
add `--depth: int` to `gm clone`

### DIFF
--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -87,6 +87,7 @@ export def "gm clone" [
 
     let urls = get-fetch-push-urls $repository $fetch $push $ssh
 
+    mut args = [$urls.fetch $local_path --origin $remote]
     if $depth != null {
         if ($depth < 1) {
             let span = metadata $depth | get span
@@ -100,18 +101,18 @@ export def "gm clone" [
             }
         }
 
+        $args = ($args ++ --depth ++ $depth)
+
         if $bare {
-            ^git clone $urls.fetch $local_path --origin $remote --depth $depth --bare
-        } else {
-            ^git clone $urls.fetch $local_path --origin $remote --depth $depth
+            $args = ($args ++ --bare)
         }
     } else {
         if $bare {
-            ^git clone $urls.fetch $local_path --origin $remote --bare
-        } else {
-            ^git clone $urls.fetch $local_path --origin $remote
+            $args = ($args ++ --bare)
         }
     }
+
+    ^git clone $args
 
     ^git -C $local_path remote set-url $remote $urls.fetch
     ^git -C $local_path remote set-url $remote --push $urls.push

--- a/nu-git-manager/mod.nu
+++ b/nu-git-manager/mod.nu
@@ -57,6 +57,9 @@ export def "gm" []: nothing -> nothing {
 #
 #     setup a public repo in the local store and use HTTP to fetch without PAT and push with SSH
 #     > gm clone https://github.com/amtoine/nu-git-manager --fetch https --push ssh
+#
+#     clone a big repo as a single commit, avoiding all intermediate Git deltas
+#     > gm clone https://github.com/neovim/neovim --depth 1
 export def "gm clone" [
     url: string # the URL to the repository to clone, supports HTTPS and SSH links, as well as references ending in `.git` or starting with `git@`
     --remote: string = "origin" # the name of the remote to setup


### PR DESCRIPTION
this PR
- adds a `--depth: int` option to `gm clone` to clone repos up to a certain depth
- adds an example to clone a repo with a single commit, which is much smaller for big repos with a long history
- refactor the `git clone` call by computing an `args: list<string>` before hand