### PR TITLE
test the Nupm installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,6 @@ jobs:
 
       - name: Run the tests
         run: |
+          # FIXME: is there a way to not rely on hardcoded paths here?
           use ~/.local/share/nupm/modules/nupm
           nupm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           use /tmp/nupm/nupm
           with-env {NUPM_HOME: ~/.local/share/nupm} {
+            # FIXME: use --no-confirm option
             mkdir ~/.local/share/nupm
             nupm install --force --path /tmp/nupm
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,18 @@ jobs:
         with:
           version: '0.86'
 
-      - name: Install Nupm from Source
-        run: git clone --depth 1 https://github.com/nushell/nupm ~/nupm/
+      - name: Download the source of Nupm
+        run: git clone --depth 1 https://github.com/nushell/nupm /tmp/nupm/
+
+      - name: Install Nupm
+        run: |
+          use /tmp/nupm/nupm
+          nupm install --force --path /tmp/nupm
 
       - name: Show Nushell Version
         run: version
 
       - name: Run the tests
         run: |
-          use ~/nupm/nupm/
+          use nupm
           nupm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Install Nupm
         run: |
           use /tmp/nupm/nupm
-          nupm install --force --path /tmp/nupm
+          with-env {NUPM_HOME: ~/.local/share/nupm} {
+            mkdir ~/.local/share/nupm
+            nupm install --force --path /tmp/nupm
+          }
 
       - name: Show Nushell Version
         run: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           use /tmp/nupm/nupm
           with-env {NUPM_HOME: ("~/.local/share/nupm" | path expand)} {
             # FIXME: use --no-confirm option
+            # related to https://github.com/nushell/nupm/pull/42
             mkdir ("~/.local/share/nupm" | path expand)
             nupm install --force --path /tmp/nupm
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,5 @@ jobs:
 
       - name: Run the tests
         run: |
-          use nupm
+          use ~/.local/share/nupm/modules/nupm
           nupm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Install Nupm
         run: |
           use /tmp/nupm/nupm
-          with-env {NUPM_HOME: ~/.local/share/nupm} {
+          with-env {NUPM_HOME: ("~/.local/share/nupm" | path expand)} {
             # FIXME: use --no-confirm option
-            mkdir ~/.local/share/nupm
+            mkdir ("~/.local/share/nupm" | path expand)
             nupm install --force --path /tmp/nupm
           }
 

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -214,3 +214,17 @@ export def cache-manipulation [] {
 
     rm --recursive --verbose --force $CACHE_DIR
 }
+
+export def install-package [] {
+    use ~/.local/share/nupm/modules/nupm
+
+    with-env {NUPM_HOME: ($nu.temp-path | path join "nu-git-manager/tests" (random uuid))} {
+        mkdir $env.NUPM_HOME;
+        nupm install --path .
+
+        assert length (ls ($env.NUPM_HOME | path join "scripts")) 0
+        assert equal (ls ($env.NUPM_HOME | path join "modules") --short-names | get name) [nu-git-manager, nu-git-manager-sugar]
+
+        rm --recursive --force --verbose $env.NUPM_HOME
+    }
+}

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -219,6 +219,7 @@ export def install-package [] {
     use ~/.local/share/nupm/modules/nupm
 
     with-env {NUPM_HOME: ($nu.temp-path | path join "nu-git-manager/tests" (random uuid))} {
+        # FIXME: use --no-confirm option
         mkdir $env.NUPM_HOME;
         nupm install --path .
 

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -216,6 +216,7 @@ export def cache-manipulation [] {
 }
 
 export def install-package [] {
+    # FIXME: is there a way to not rely on hardcoded paths here?
     use ~/.local/share/nupm/modules/nupm
 
     with-env {NUPM_HOME: ($nu.temp-path | path join "nu-git-manager/tests" (random uuid))} {

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -221,6 +221,7 @@ export def install-package [] {
 
     with-env {NUPM_HOME: ($nu.temp-path | path join "nu-git-manager/tests" (random uuid))} {
         # FIXME: use --no-confirm option
+        # related to https://github.com/nushell/nupm/pull/42
         mkdir $env.NUPM_HOME;
         nupm install --path .
 


### PR DESCRIPTION
after talking with @stormasm about the new `nu-git-manager` / `nu-git-manager-sugar` install, i thought we could try to test the Nupm install inside our CI.

this PR is this experiment:
- install Nupm with itself in an extra CI step
- use `~/.local/share/nupm/modules/nupm` as the *standard* location for the nupm package
- add the `install-package` test which
    - installs `nu-git-manager` to the Nupm store
    - checks that there is no scripts
    - checks that there are the two `nu-git-manager` and `nu-git-manager-sugar` modules installed

> **Note**
> currently there is no `--no-confirm` option for `nupm install`, so the `NUPM_HOME` has to be created manually with `mkdir` prior to the install => i've added `FIXME`s for that
> should be fixed with https://github.com/nushell/nupm/pull/42