### PR TITLE
clone the Nupm repo with a single depth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           version: '0.86'
 
       - name: Install Nupm from Source
-        run: git clone https://github.com/nushell/nupm ~/nupm/
+        run: git clone --depth 1 https://github.com/nushell/nupm ~/nupm/
 
       - name: Show Nushell Version
         run: version


### PR DESCRIPTION
this PR uses `git clone --depth 1` in the CI to install Nupm.
this should reduce the size of the clone and help the CI.