### PR TITLE
add internal documentation

### DIFF
--- a/src/nu-git-manager/fs/cache.nu
+++ b/src/nu-git-manager/fs/cache.nu
@@ -1,5 +1,8 @@
 use path.nu "path sanitize"
 
+# get the path to the cache of the local store of repos
+#
+# /!\ this command will sanitize the output path. /!\
 export def get-repo-store-cache-path []: nothing -> path {
     $env.GIT_REPOS_CACHE?
         | default (
@@ -11,6 +14,7 @@ export def get-repo-store-cache-path []: nothing -> path {
         | path sanitize
 }
 
+# make sure the cache file exists and give a nice error otherwise
 export def check-cache-file [cache_file: path]: nothing -> nothing {
     if not ($cache_file | path exists) {
         error make --unspanned {
@@ -22,14 +26,23 @@ export def check-cache-file [cache_file: path]: nothing -> nothing {
     }
 }
 
+# open the cache file
+#
+# /!\ this command will return sanitized paths if `add-to-cache` or `gm update-cache` have been used. /!\
 export def open-cache [cache_file: path]: nothing -> list<path> {
     open --raw $cache_file | from nuon
 }
 
+# save a list of paths to the cache file
+#
+# /!\ this command will sanitize the paths for the caller. /!\
 export def save-cache [cache_file: path]: list<path> -> nothing {
     each { path sanitize } | to nuon | save --force $cache_file
 }
 
+# add a new path to the cache file
+#
+# /!\ this command will sanitize the paths for the caller. /!\
 export def add-to-cache [cache_file: path, new_path: path]: nothing -> nothing {
     print --no-newline "updating cache... "
     open-cache $cache_file
@@ -40,12 +53,21 @@ export def add-to-cache [cache_file: path, new_path: path]: nothing -> nothing {
     print "done"
 }
 
+# remove an old path from the cache file
+#
+# /!\ this command will sanitize the paths for the caller. /!\
 export def remove-from-cache [cache_file: path, old_path: path]: nothing -> nothing {
     print --no-newline "updating cache... "
     open-cache $cache_file | where $it != ($old_path | path sanitize) | save-cache $cache_file
     print "done"
 }
 
+# clean and prepare the cache directory
+#
+# this command will
+# - remove any previous cache file: this avoids having an invalid file, e.g. a directory, in the
+#  same place as the expected cache file
+# - create the parent directory of the cache file
 export def clean-cache-dir [cache_file: path]: nothing -> nothing {
     rm --recursive --force $cache_file
     mkdir ($cache_file | path dirname)

--- a/src/nu-git-manager/fs/cache.nu
+++ b/src/nu-git-manager/fs/cache.nu
@@ -42,7 +42,7 @@ export def remove-from-cache [cache_file: path, old_path: path]: nothing -> noth
     print "done"
 }
 
-export def make-cache [cache_file: path]: nothing -> nothing {
+export def clean-cache-dir [cache_file: path]: nothing -> nothing {
     rm --recursive --force $cache_file
     mkdir ($cache_file | path dirname)
 }

--- a/src/nu-git-manager/fs/cache.nu
+++ b/src/nu-git-manager/fs/cache.nu
@@ -27,18 +27,22 @@ export def open-cache [cache_file: path]: nothing -> list<path> {
 }
 
 export def save-cache [cache_file: path]: list<path> -> nothing {
-    to nuon | save --force $cache_file
+    each { path sanitize } | to nuon | save --force $cache_file
 }
 
 export def add-to-cache [cache_file: path, new_path: path]: nothing -> nothing {
     print --no-newline "updating cache... "
-    open-cache $cache_file | append $new_path | uniq | sort | save-cache $cache_file
+    open-cache $cache_file
+        | append ($new_path | path sanitize)
+        | uniq
+        | sort
+        | save-cache $cache_file
     print "done"
 }
 
 export def remove-from-cache [cache_file: path, old_path: path]: nothing -> nothing {
     print --no-newline "updating cache... "
-    open-cache $cache_file | where $it != $old_path | save-cache $cache_file
+    open-cache $cache_file | where $it != ($old_path | path sanitize) | save-cache $cache_file
     print "done"
 }
 

--- a/src/nu-git-manager/fs/store.nu
+++ b/src/nu-git-manager/fs/store.nu
@@ -1,12 +1,24 @@
 use std log
 use path.nu "path sanitize"
 
+# get the root of the local repo store
+#
+# /!\ this command will sanitize the output path. /!\
 export def get-repo-store-path []: nothing -> path {
     $env.GIT_REPOS_HOME? | default (
         $env.XDG_DATA_HOME? | default ($nu.home-path | path join ".local/share") | path join "repos"
     ) | path expand | path sanitize
 }
 
+# list all the repos stored locally
+#
+# this command will return the empty list if the store does not exist.
+#
+# this command will
+# - catch *bare* repositories
+# - remove duplicates coming from nested repositories such as Git submodules
+#
+# /!\ this command will sanitize the output list of paths. /!\
 export def list-repos-in-store []: nothing -> list<path> {
     if not (get-repo-store-path | path exists) {
         log debug $"the store does not exist: `(get-repo-store-path)`"

--- a/src/nu-git-manager/git/url.nu
+++ b/src/nu-git-manager/git/url.nu
@@ -1,5 +1,13 @@
 use ../fs/path.nu "path sanitize"
 
+# parse the URL of a Git repo
+#
+# this command will isolate
+# - the host, e.g. `github.com`
+# - the owner, e.g. `amtoine`
+# - the group, e.g. GitLab repos can be stored in subgroups, which can either be seen as subfields
+#   to the owner or superfields of the repo
+# - the repo, e.g. `nu-git-manager`
 export def parse-git-url []: string -> record<host: string, owner: string, group: path, repo: string> {
     str replace --regex '^git@(.*):' 'ssh://$1/'
         | str replace --regex '\.git$' ''
@@ -29,11 +37,12 @@ export def parse-git-url []: string -> record<host: string, owner: string, group
         | into record
 }
 
+# compute the FETCH and PUSH remote URLs for a parsed repository, based on user input
 export def get-fetch-push-urls [
-    repository: record<host: string, owner: string, group: path, repo: string>, # typically from `parse-git-url`
-    fetch: string, # one of 'https', 'ssh', 'git', or empty
-    push: string, # one of 'https', 'ssh', 'git', or empty
-    ssh: bool,
+    repository: record<host: string, owner: string, group: path, repo: string>, # the parsed repository (typically from `parse-git-url`)
+    fetch: string, # user input: one of 'https', 'ssh', 'git', or empty (typically from `gm clone --fetch`)
+    push: string, # user input: one of 'https', 'ssh', 'git', or empty (typically from `gm clone --push`)
+    ssh: bool, # user input (typically from `gm clone --ssh`)
 ]: nothing -> record<fetch: string, push: string> {
     let base_url = {
         scheme: null,

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -129,6 +129,8 @@ export def "gm clone" [
 
 # list all the local repositories in your local store
 #
+# /!\ this command will return sanitized paths. /!\
+#
 # # Examples
 #     list all the repositories in the store
 #     > gm list
@@ -154,6 +156,8 @@ export def "gm list" [
 }
 
 # get current status about the repositories managed by `nu-git-manager`
+#
+# /!\ `$.root.path` and `$.cache.path` will be sanitized /!\
 #
 # Examples
 #     getting status when everything is fine

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -3,7 +3,7 @@ use std log
 use fs/store.nu [get-repo-store-path, list-repos-in-store]
 use fs/cache.nu [
     get-repo-store-cache-path, check-cache-file, add-to-cache, remove-from-cache, open-cache,
-    save-cache, make-cache
+    save-cache, clean-cache-dir
 ]
 use git/url.nu [parse-git-url, get-fetch-push-urls]
 
@@ -221,7 +221,7 @@ export def "gm status" []: nothing -> record<root: record<path: path, exists: bo
 #     > gm update-cache
 export def "gm update-cache" []: nothing -> nothing {
     let cache_file = get-repo-store-cache-path
-    make-cache $cache_file
+    clean-cache-dir $cache_file
 
     print --no-newline "updating cache... "
     list-repos-in-store | save-cache $cache_file

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -4,7 +4,7 @@ use ../src/nu-git-manager/git/url.nu [parse-git-url, get-fetch-push-urls]
 use ../src/nu-git-manager/fs/store.nu [get-repo-store-path, list-repos-in-store]
 use ../src/nu-git-manager/fs/cache.nu [
     get-repo-store-cache-path, check-cache-file, add-to-cache, remove-from-cache, open-cache,
-    save-cache, make-cache
+    save-cache, clean-cache-dir
 ]
 use ../src/nu-git-manager/fs/path.nu "path sanitize"
 
@@ -191,7 +191,7 @@ export def cache-manipulation [] {
 
     assert error { check-cache-file $CACHE }
 
-    make-cache $CACHE
+    clean-cache-dir $CACHE
     assert ($CACHE | path dirname | path exists)
 
     [] | save-cache $CACHE


### PR DESCRIPTION
after discussing with @stormasm a bit about the `make-cache` command, i thought we could add some internal documentation, not too much but just enough to make sense :yum: 

## changelog
- rename `make-cache` to `clean-cache-dir` to hopefully make more sense
- *sanitize* the paths given to `add-to-cache`, `save-cache` and `remove-from-cache` => the paths given to them were not always *sanitized*, this should help make this *sanitization* more consistent
- add some documentation to the internal commands, for when we'll have true LSP support :wink: 
  - on the biggest thing is telling from the outside whether a path is *sanitized* or not