### PR TITLE
add missing tests

### DIFF
--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -199,6 +199,8 @@ export def cache-manipulation [] {
     [] | save-cache $CACHE
     assert cache []
 
+    check-cache-file $CACHE
+
     add-to-cache $CACHE ("foo" | path expand | path sanitize)
     assert cache ["foo"]
 

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -130,6 +130,8 @@ export def list-all-repos-in-store [] {
         $nu.temp-path | path join "nu-git-manager/tests/list-all-repos-in-store" | path sanitize
     )
 
+    assert length (with-env {GIT_REPOS_HOME: $BASE} { list-repos-in-store }) 0
+
     if ($BASE | path exists) {
         rm --recursive --verbose --force $BASE
     }


### PR DESCRIPTION
this PR makes sure
- `list-repos-in-store` gives an empty list when the store is not there
- `check-cache-file` does not give an error when the cache file is created