### PR TITLE
fix `$.span` in `error make`

### DIFF
--- a/src/nu-git-manager-sugar/gist.nu
+++ b/src/nu-git-manager-sugar/gist.nu
@@ -65,13 +65,11 @@ export def list [
     )}
 
     if ($user | is-empty) {
-        let span = (metadata $user | get span)
         error make {
             msg: $"(ansi red)gist::no_user_given(ansi reset)"
             label: {
                 text: "no user given"
-                start: $span.start
-                end: $span.end
+                span: (metadata $user | get span)
             }
         }
     }

--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -127,13 +127,11 @@ export def "remote add" [
     --ssh  # use SSH as the communication protocol
 ] {
     if $name in (remote list | get remote) {
-        let span = (metadata $name | get span)
         error make {
             msg: $"(ansi red_bold)remote_already_in_index(ansi reset)"
             label: {
                 text: $"already a remote of ($env.PWD)"
-                start: $span.start
-                end: $span.end
+                span: (metadata $name | get span)
             }
         }
     }
@@ -186,13 +184,11 @@ export def fixup [
     revision: string  # the revision of the Git worktree to fixup
 ] {
     if (do --ignore-errors { git rev-parse $revision } | complete | get exit_code) != 0 {
-        let span = (metadata $revision | get span)
         error make {
             msg: $"(ansi red_bold)revision_not_found(ansi reset)"
             label: {
                 text: $"($revision) not found in the working tree of ($env.PWD)"
-                start: $span.start
-                end: $span.end
+                span: (metadata $revision | get span)
             }
         }
     }

--- a/src/nu-git-manager/error/error.nu
+++ b/src/nu-git-manager/error/error.nu
@@ -6,8 +6,7 @@ export def throw-error [
         msg: $"(ansi red_bold)($error.msg)(ansi reset)"
         label: {
             text: $error.label.text
-            start: $error.label.span.start
-            end: $error.label.span.end
+            span: $error.label.span
         }
     }
 }


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/10923

## description
with https://github.com/nushell/nushell/pull/10923, `error make` now takes `$.label.span: record<start: int, end: int>` instead of `$.label.start: int` and `$.label.end: int`.
this PR prepares for the change in `0.87` :yum: 