### PR TITLE
check if output of `input list` is `null`

### DIFF
--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -278,7 +278,7 @@ export def "gm remove" [
                 $choices | input list $prompt
             }
 
-            if ($choice | is-empty) {
+            if $choice == null {
                 log info "user chose to exit"
                 return
             }


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell/pull/10913

## description
this will use the new fact that `input list` returns `null` if the user does not choose any option, which is more general.

this will become available in next release: `0.87`
