### PR TITLE
use `^git` in the tests

### DIFF
--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -151,9 +151,9 @@ export def list-all-repos-in-store [] {
 
     for repo in $store {
         if $repo.is_bare {
-            git init --bare ($BASE | path join $repo.path)
+            ^git init --bare ($BASE | path join $repo.path)
         } else {
-            git init ($BASE | path join $repo.path)
+            ^git init ($BASE | path join $repo.path)
         }
     }
 


### PR DESCRIPTION
as per title, for consistency with the rest of `nu-git-manager`.