### PR TITLE
show the stdout of the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
         run: |
           # FIXME: is there a way to not rely on hardcoded paths here?
           use ~/.local/share/nupm/modules/nupm
-          nupm test
+          nupm test --show-stdout


### PR DESCRIPTION
in case we need more information in the CI output for debugging, this PR adds the `--show-stdout` switch to the `nupm test` call in the CI.