### PR TITLE
refactor: move completions to their own module

### DIFF
--- a/src/nu-git-manager/completions/nu-complete.nu
+++ b/src/nu-git-manager/completions/nu-complete.nu
@@ -1,0 +1,9 @@
+export def git-protocols []: nothing -> table<value: string, description: string> {
+    [
+        [value, description];
+
+        ["https", "use the HTTP protocol: will require a PAT authentification for private repositories"],
+        ["ssh", "use the SSH protocol: will require a passphrase unless setup otherwise"],
+        ["git", "use the GIT protocol: useful when cloning a *Suckless* repo"],
+    ]
+}

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -8,15 +8,7 @@ use fs/cache.nu [
 use git/url.nu [parse-git-url, get-fetch-push-urls]
 use error/error.nu [throw-error]
 
-def "nu-complete git-protocols" []: nothing -> table<value: string, description: string> {
-    [
-        [value, description];
-
-        ["https", "use the HTTP protocol: will require a PAT authentification for private repositories"],
-        ["ssh", "use the SSH protocol: will require a passphrase unless setup otherwise"],
-        ["git", "use the GIT protocol: useful when cloning a *Suckless* repo"],
-    ]
-}
+use completions/nu-complete.nu
 
 # manage your Git repositories with the main command of `nu-git-manager`
 #


### PR DESCRIPTION
this PR moves the completion commands from the main module to a `completions/nu-complete.nu` submodule.