### PR TITLE
add a command to clean the store from empty directories

### DIFF
--- a/src/nu-git-manager/fs/dir.nu
+++ b/src/nu-git-manager/fs/dir.nu
@@ -1,3 +1,5 @@
+use path.nu ["path sanitize"]
+
 # clean all empty directories recursively, starting from a list of empty leaves
 #
 # /!\ this command will return sanitized paths /!\

--- a/src/nu-git-manager/fs/dir.nu
+++ b/src/nu-git-manager/fs/dir.nu
@@ -1,0 +1,23 @@
+# clean all empty directories recursively, starting from a list of empty leaves
+#
+# /!\ this command will return sanitized paths /!\
+export def clean-empty-directories-rec []: list<path> -> list<path> {
+    let deleted = unfold $in {|directories|
+        let next = $directories | each {|it|
+            ^rmdir $it
+
+            let parent = $it | path dirname;
+            if (ls $parent | is-empty) {
+                $parent | path sanitize
+            }
+        }
+
+        if ($next | is-empty) {
+            {out: $directories}
+        } else {
+            {out: $directories, next: $next}
+        }
+    }
+
+    $deleted | flatten
+}

--- a/src/nu-git-manager/fs/dir.nu
+++ b/src/nu-git-manager/fs/dir.nu
@@ -6,7 +6,7 @@ use path.nu ["path sanitize"]
 export def clean-empty-directories-rec []: list<path> -> list<path> {
     let deleted = unfold $in {|directories|
         let next = $directories | each {|it|
-            rm --force --verbose $it
+            rm --force $it
 
             let parent = $it | path dirname;
             if (ls $parent | is-empty) {

--- a/src/nu-git-manager/fs/dir.nu
+++ b/src/nu-git-manager/fs/dir.nu
@@ -6,7 +6,7 @@ use path.nu ["path sanitize"]
 export def clean-empty-directories-rec []: list<path> -> list<path> {
     let deleted = unfold $in {|directories|
         let next = $directories | each {|it|
-            ^rmdir $it
+            rm --force --verbose $it
 
             let parent = $it | path dirname;
             if (ls $parent | is-empty) {

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -319,11 +319,17 @@ export def "gm remove" [
         }
     }
 
-    rm --recursive --force --verbose ($root | path join $repo_to_remove)
+    let repo_to_remove = $root | path join $repo_to_remove
+
+    rm --recursive --force --verbose $repo_to_remove
 
     let cache_file = get-repo-store-cache-path
     check-cache-file $cache_file
-    remove-from-cache $cache_file ($root | path join $repo_to_remove)
+    remove-from-cache $cache_file $repo_to_remove
+
+    if (ls ($repo_to_remove | path dirname) | is-empty) {
+        [($repo_to_remove | path dirname)] | clean-empty-directories-rec
+    }
 
     null
 }

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -5,6 +5,7 @@ use fs/cache.nu [
     get-repo-store-cache-path, check-cache-file, add-to-cache, remove-from-cache, open-cache,
     save-cache, clean-cache-dir
 ]
+use fs/dir.nu [clean-empty-directories-rec]
 use git/url.nu [parse-git-url, get-fetch-push-urls]
 use error/error.nu [throw-error]
 
@@ -354,22 +355,5 @@ export def "gm clean" [
         return $empty_non_repo_directories_in_store
     }
 
-    let deleted = unfold $empty_non_repo_directories_in_store {|directories|
-        let next = $directories | each {|it|
-            ^rmdir $it
-
-            let parent = $it | path dirname;
-            if (ls $parent | is-empty) {
-                $parent
-            }
-        }
-
-        if ($next | is-empty) {
-            {out: $directories}
-        } else {
-            {out: $directories, next: $next}
-        }
-    }
-
-    $deleted | flatten
+    $empty_non_repo_directories_in_store | clean-empty-directories-rec
 }

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -352,6 +352,7 @@ export def "gm clean" [
     let empty_directories_in_store = ls (gm status | get root.path | path join "**")
         | where (ls $it.name | is-empty)
         | get name
+        | path expand
         | each { path sanitize }
     let cached_repos = gm list --full-path
 

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -352,6 +352,7 @@ export def "gm clean" [
     let empty_directories_in_store = ls (gm status | get root.path | path join "**")
         | where (ls $it.name | is-empty)
         | get name
+        | each { path sanitize }
     let cached_repos = gm list --full-path
 
     let empty_non_repo_directories_in_store = $empty_directories_in_store

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -6,6 +6,7 @@ use fs/cache.nu [
     save-cache, clean-cache-dir
 ]
 use fs/dir.nu [clean-empty-directories-rec]
+use fs/path.nu ["path sanitize"]
 use git/url.nu [parse-git-url, get-fetch-push-urls]
 use error/error.nu [throw-error]
 

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -330,11 +330,10 @@ export def "gm remove" [
     if (ls ($repo_to_remove | path dirname) | is-empty) {
         let deleted = [($repo_to_remove | path dirname)] | clean-empty-directories-rec
 
-        print (
-            ["the following empty directories have been removed:"]
-                | append $deleted
-                | str join "\n- "
-        )
+        print "the following empty directories have been removed:"
+        print $deleted
+    } else {
+        print "no empty directory to clean"
     }
 
     null

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -328,7 +328,13 @@ export def "gm remove" [
     remove-from-cache $cache_file $repo_to_remove
 
     if (ls ($repo_to_remove | path dirname) | is-empty) {
-        [($repo_to_remove | path dirname)] | clean-empty-directories-rec
+        let deleted = [($repo_to_remove | path dirname)] | clean-empty-directories-rec
+
+        print (
+            ["the following empty directories have been removed:"]
+                | append $deleted
+                | str join "\n- "
+        )
     }
 
     null

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -246,17 +246,20 @@ export def store-cleaning-after-remove [] {
 export def store-cleaning [] {
     run-with-env --prepare-cache {
         gm clone https://github.com/amtoine/nu-git-manager --depth 1
-        rm --force --recursive --verbose (
-            $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager"
+
+        let repo = (
+            $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager" | path sanitize
         )
 
-        let expected = [($env.GIT_REPOS_HOME | path join "github.com/amtoine")]
+        rm --force --recursive --verbose $repo
+
+        let expected = [($repo | path dirname)]
         assert equal (gm clean --list) $expected
 
         let expected = [
-            ($env.GIT_REPOS_HOME | path join "github.com/amtoine")
-            ($env.GIT_REPOS_HOME | path join "github.com")
-            $env.GIT_REPOS_HOME
+            ($repo | path dirname)
+            ($repo | path dirname --num-levels 2)
+            ($repo | path dirname --num-levels 3)
         ]
         assert equal (gm clean) $expected
 

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -231,3 +231,14 @@ export def remove [] {
         assert equal (gm list) []
     }
 }
+
+export def store-cleaning [] {
+    run-with-env --prepare-cache {
+        gm clone https://github.com/amtoine/nu-git-manager --depth 1
+        gm remove "github.com/amtoine/nu-git-manager" --no-confirm
+
+        # NOTE: the root should not exist anymore because there was only one repo in it and it's
+        # been cleaned
+        assert not ($env.GIT_REPOS_HOME | path exists)
+    }
+}

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -232,10 +232,33 @@ export def remove [] {
     }
 }
 
-export def store-cleaning [] {
+export def store-cleaning-after-remove [] {
     run-with-env --prepare-cache {
         gm clone https://github.com/amtoine/nu-git-manager --depth 1
         gm remove "github.com/amtoine/nu-git-manager" --no-confirm
+
+        # NOTE: the root should not exist anymore because there was only one repo in it and it's
+        # been cleaned
+        assert not ($env.GIT_REPOS_HOME | path exists)
+    }
+}
+
+export def store-cleaning [] {
+    run-with-env --prepare-cache {
+        gm clone https://github.com/amtoine/nu-git-manager --depth 1
+        rm --force --recursive --verbose (
+            $env.GIT_REPOS_HOME | path join "github.com/amtoine/nu-git-manager"
+        )
+
+        let expected = [($env.GIT_REPOS_HOME | path join "github.com/amtoine")]
+        assert equal (gm clean --list) $expected
+
+        let expected = [
+            ($env.GIT_REPOS_HOME | path join "github.com/amtoine")
+            ($env.GIT_REPOS_HOME | path join "github.com")
+            $env.GIT_REPOS_HOME
+        ]
+        assert equal (gm clean) $expected
 
         # NOTE: the root should not exist anymore because there was only one repo in it and it's
         # been cleaned

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -243,7 +243,7 @@ export def install-package [] {
 }
 
 export def store-cleaning [] {
-    with-env {GIT_REPOS_HOME: "/tmp/nu-git-manager/foo"} {
+    with-env {GIT_REPOS_HOME: "/tmp/nu-git-manager/store-cleaning"} {
         mkdir $env.GIT_REPOS_HOME
         # NOTE: this is to make sure the root of the test is not empty
         # we don't want the test to go remove empty directories outside...

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -258,6 +258,8 @@ export def store-cleaning [] {
         let actual = $empty_directories
             | each {|it|
                 let path = $env.GIT_REPOS_HOME | path join $it | path sanitize
+
+                print $"making `($path)`"
                 mkdir $path
 
                 $path

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -257,7 +257,7 @@ export def store-cleaning [] {
 
         let actual = $empty_directories
             | each {|it|
-                let path = $env.GIT_REPOS_HOME | path join $it
+                let path = $env.GIT_REPOS_HOME | path join $it | path sanitize
                 mkdir $path
 
                 $path

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -265,7 +265,7 @@ export def store-cleaning [] {
                 $path
             }
             | clean-empty-directories-rec
-            | str replace $env.GIT_REPOS_HOME ''
+            | str replace ($env.GIT_REPOS_HOME | path sanitize) ''
             | str trim --char '/'
         let expected = [
             "foo/bar",

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -243,7 +243,7 @@ export def install-package [] {
 }
 
 export def store-cleaning [] {
-    with-env {GIT_REPOS_HOME: "/tmp/nu-git-manager/store-cleaning"} {
+    with-env {GIT_REPOS_HOME: ($nu.home-path | path join ".local/share/nu-git-manager-tests")} {
         mkdir $env.GIT_REPOS_HOME
         # NOTE: this is to make sure the root of the test is not empty
         # we don't want the test to go remove empty directories outside...

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -245,6 +245,8 @@ export def install-package [] {
 export def store-cleaning [] {
     with-env {GIT_REPOS_HOME: "/tmp/nu-git-manager/foo"} {
         mkdir $env.GIT_REPOS_HOME
+        # NOTE: this is to make sure the root of the test is not empty
+        # we don't want the test to go remove empty directories outside...
         touch ($env.GIT_REPOS_HOME | path join ".lock")
 
         let empty_directories = [


### PR DESCRIPTION
this will close #76.

this PR
- adds the `fs/dir clean-empty-directories-rec` command and it's test `tests store-cleaning`
- adds the `gm clean` command and test in `tests gm store-cleaning`
- cleans the parent of any removed directory after `gm remove` and test that in `tests gm store-cleaning-after-remove`