### PR TITLE
allow to filter tests in `toolkit test`

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -3,14 +3,15 @@
 # > **Important**  
 # > the `toolkit test` command requires [Nupm](https://github.com/nushell/nupm) to be installed
 export def "test" [
+    pattern?: string = "" # the pattern a test name should match to run
     --verbose # show the output of each tests
 ] {
     use nupm
 
     if $verbose {
-        nupm test --show-stdout
+        nupm test $pattern --show-stdout
     } else {
-        nupm test
+        nupm test $pattern
     }
 }
 


### PR DESCRIPTION
because `nupm test` takes an optional `pattern?: string` argument, i think having it on `toolkit test` as well would be very handy to run a subset of the tests.

this PR adds that precisely.

> **Note**
> when the pattern is `""` it will run all the tests, thus it's the default