### PR TITLE
fix: do not allow invalid user-package import in the tests

### DIFF
--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -324,5 +324,7 @@ export def "gm remove" [
     check-cache-file $cache_file
     remove-from-cache $cache_file ($root | path join $repo_to_remove)
 
+    "foo" | path sanitize
+
     null
 }

--- a/src/nu-git-manager/mod.nu
+++ b/src/nu-git-manager/mod.nu
@@ -324,7 +324,5 @@ export def "gm remove" [
     check-cache-file $cache_file
     remove-from-cache $cache_file ($root | path join $repo_to_remove)
 
-    "foo" | path sanitize
-
     null
 }

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -231,3 +231,7 @@ export def remove [] {
         assert equal (gm list) []
     }
 }
+
+export def user-import [] {
+    ^$nu.current-exe --commands "use ./src/nu-git-manager/ *"
+}


### PR DESCRIPTION
should
- close #83 

## description
this PR adds the `tests gm user-import` test to make sure users will be able to import the package without issues.

i've left a bad commit intentionally that the previous tests did not pick the issue, then reverted it :+1: 