### PR TITLE
fix sync CI by giving SSH token to `actions/checkout`

### DIFF
--- a/.github/actions/sync_action/action.yml
+++ b/.github/actions/sync_action/action.yml
@@ -48,9 +48,7 @@ runs:
       working-directory: /tmp/nu-git-manager
 
     - name: "Push to remote"
-      run: |
-        git remote set-url origin git@github.com:amtoine/nu-git-manager.git
-        git push origin nightly
+      run: git push origin nightly
       shell: bash
       working-directory: /tmp/nu-git-manager
       if: ${{ inputs.do_push == 'true' && !env.ACT }}

--- a/.github/workflows/sync_nightly.yml
+++ b/.github/workflows/sync_nightly.yml
@@ -11,6 +11,8 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ github.token }}
 
       - uses: ./.github/actions/sync_action
         with:


### PR DESCRIPTION
as per title, reverts #89 