### PR TITLE
use `generate` instead of `unfold`

### DIFF
--- a/src/nu-git-manager/fs/dir.nu
+++ b/src/nu-git-manager/fs/dir.nu
@@ -4,7 +4,7 @@ use path.nu ["path sanitize"]
 #
 # /!\ this command will return sanitized paths /!\
 export def clean-empty-directories-rec []: list<path> -> list<path> {
-    let deleted = unfold $in {|directories|
+    let deleted = generate $in {|directories|
         let next = $directories | each {|it|
             rm --force $it
 


### PR DESCRIPTION
- should close #96

## description
`unfold` is being deprecated into `generate`.
this PR fixes that.