### PR TITLE
clean sugar git

### DIFF
--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -83,7 +83,6 @@ export def "gm repo remote list" []: nothing -> table<remote: string, fetch: str
     ^git remote --verbose
         | detect columns --no-headers
         | rename remote url mode
-        | str trim
         | group-by remote
         | transpose
         | update column1 {

--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -11,10 +11,10 @@ export def operations [] {
 }
 
 # get the commit hash of any revision
-export def "get commit" [
-    revision: string = "HEAD"  # the revision to get the hash of (defaults to "HEAD")
-] {
-    git rev-parse $revision | str trim
+export def "gm repo get commit" [
+    revision: string = "HEAD"  # the revision to get the hash of
+]: nothing -> string {
+    ^git rev-parse $revision
 }
 
 # compare two revisions in a `git` repository

--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -35,7 +35,7 @@ export def compare [
 }
 
 def repo-root [] {
-    git rev-parse --show-toplevel | str trim
+    ^git rev-parse --show-toplevel
 }
 
 # removes the index lock
@@ -52,7 +52,7 @@ export def "lock clean" [] {
 }
 
 # go to the root of the repository from anywhere in the worktree
-export def --env root [] {
+export def --env "gm repo goto root" []: nothing -> nothing {
     cd (repo-root)
 }
 

--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -4,6 +4,7 @@ use std log
 export def "gm repo get commit" [
     revision: string = "HEAD"  # the revision to get the hash of
 ]: nothing -> string {
+    # FIXME: this `str trim` sounds like a bug :thinking:
     ^git rev-parse $revision | str trim
 }
 

--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -79,6 +79,7 @@ export def "gm repo is-ancestor" [
 
 # get the list of all the remotes in the current repository
 export def "gm repo remote list" []: nothing -> table<remote: string, fetch: string, push: string> {
+    # FIXME: use the helper `list-remotes` command from ../nu-git-manager/git/repo.nu:29
     ^git remote --verbose
         | detect columns --no-headers
         | rename remote url mode

--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -118,16 +118,18 @@ export def "gm repo is-ancestor" [
 }
 
 # get the list of all the remotes in the current repository
-export def "remote list" [] {
+export def "gm repo remote list" []: nothing -> table<remote: string, fetch: string, push: string> {
     ^git remote --verbose
-    | detect columns --no-headers
-    | rename remote url mode
-    | str trim
-    | group-by remote
-    | transpose
-    | update column1 { reject remote | select mode url | transpose -r | into record }
-    | flatten
-    | rename remote fetch push
+        | detect columns --no-headers
+        | rename remote url mode
+        | str trim
+        | group-by remote
+        | transpose
+        | update column1 {
+            reject remote | select mode url | transpose --header-row | into record
+        }
+        | flatten
+        | rename remote fetch push
 }
 
 # add a new remote to the repository

--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -4,7 +4,7 @@ use std log
 export def "gm repo get commit" [
     revision: string = "HEAD"  # the revision to get the hash of
 ]: nothing -> string {
-    ^git rev-parse $revision
+    ^git rev-parse $revision | str trim
 }
 
 def repo-root [] {

--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -101,15 +101,20 @@ export def "gm repo branches" [
 }
 
 # return true iif the first revision is an ancestor of the second
-export def is-ancestor [
+#
+# # Examples
+#     HEAD~20 is an ancestor of HEAD
+#     > gm repo is-ancestor HEAD~20 HEAD
+#     true
+#
+#     HEAD is never an ancestor of HEAD~20
+#     > gm repo is-ancestor HEAD HEAD~20
+#     false
+export def "gm repo is-ancestor" [
     a: string  # the base commit-ish revision
     b: string  # the *head* commit-ish revision
-] {
-    let exit_code = (do -i {
-        git merge-base $a $b --is-ancestor
-    } | complete | get exit_code)
-
-    $exit_code == 0
+]: nothing -> bool {
+    (do -i { ^git merge-base $a $b --is-ancestor } | complete | get exit_code) == 0
 }
 
 # get the list of all the remotes in the current repository

--- a/src/nu-git-manager/git/repo.nu
+++ b/src/nu-git-manager/git/repo.nu
@@ -22,6 +22,8 @@ export def get-root-commit [
 ]: nothing -> string {
     let repo = $repo | default (pwd)
 
+    # FIXME: this is a bug and should work without string interpolation
+    # see https://github.com/nushell/nushell/issues/11134
     $"(^git -C $repo rev-list HEAD | lines | last)"
 }
 

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -49,5 +49,11 @@ export def is-ancestor [] {
 }
 
 export def remote-list [] {
-    assert false
+    init-repo-and-cd-into
+
+    assert equal (gm repo remote list) []
+
+    ^git remote add foo foo-url
+
+    assert equal (gm repo remote list) [{remote: foo, fetch: foo-url, push: foo-url}]
 }

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -27,7 +27,14 @@ export def goto-root [] {
 }
 
 export def branches [] {
-    assert false
+    init-repo-and-cd-into
+
+    assert equal (gm repo branches) []
+
+    git checkout --orphan foo
+    git commit --allow-empty --no-gpg-sign --message "init"
+
+    assert equal (gm repo branches) [{branch: foo, remotes: []}]
 }
 
 export def is-ancestor [] {

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -31,8 +31,8 @@ export def branches [] {
 
     assert equal (gm repo branches) []
 
-    git checkout --orphan foo
-    git commit --allow-empty --no-gpg-sign --message "init"
+    ^git checkout --orphan foo
+    ^git commit --allow-empty --no-gpg-sign --message "init"
 
     assert equal (gm repo branches) [{branch: foo, remotes: []}]
 }
@@ -40,9 +40,9 @@ export def branches [] {
 export def is-ancestor [] {
     init-repo-and-cd-into
 
-    git commit --allow-empty --no-gpg-sign --message "init"
-    git commit --allow-empty --no-gpg-sign --message "c1"
-    git commit --allow-empty --no-gpg-sign --message "c2"
+    ^git commit --allow-empty --no-gpg-sign --message "init"
+    ^git commit --allow-empty --no-gpg-sign --message "c1"
+    ^git commit --allow-empty --no-gpg-sign --message "c2"
 
     assert (gm repo is-ancestor HEAD^ HEAD)
     assert not (gm repo is-ancestor HEAD HEAD^)

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -1,0 +1,23 @@
+use std assert
+
+use ../../src/nu-git-manager-sugar/ git *
+
+export def get-commit [] {
+    assert false
+}
+
+export def goto-root [] {
+    assert false
+}
+
+export def branches [] {
+    assert false
+}
+
+export def is-ancestor [] {
+    assert false
+}
+
+export def remote-list [] {
+    assert false
+}

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -1,13 +1,23 @@
 use std assert
 
 use ../../src/nu-git-manager-sugar/ git *
+use ../common/setup.nu [get-random-test-dir]
 
 export def get-commit [] {
     assert false
 }
 
 export def goto-root [] {
-    assert false
+    let repo = get-random-test-dir
+
+    ^git init $repo
+    cd $repo
+
+    mkdir foo/bar/baz
+    cd foo/bar/baz
+
+    gm repo goto root
+    assert equal (pwd) $repo
 }
 
 export def branches [] {

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -1,6 +1,7 @@
 use std assert
 
 use ../../src/nu-git-manager-sugar/ git *
+use ../../src/nu-git-manager/fs/path.nu ["path sanitize"]
 use ../common/setup.nu [get-random-test-dir]
 
 def --env init-repo-and-cd-into []: nothing -> path {
@@ -28,7 +29,7 @@ export def goto-root [] {
     cd init-repo-and-cd-into/bar/baz
 
     gm repo goto root
-    assert equal (pwd) $repo
+    assert equal (pwd | path sanitize) $repo
 }
 
 export def branches [] {

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -3,18 +3,24 @@ use std assert
 use ../../src/nu-git-manager-sugar/ git *
 use ../common/setup.nu [get-random-test-dir]
 
-export def get-commit [] {
-    assert false
-}
-
-export def goto-root [] {
+def --env init-repo-and-cd-into []: nothing -> path {
     let repo = get-random-test-dir
 
     ^git init $repo
     cd $repo
 
-    mkdir foo/bar/baz
-    cd foo/bar/baz
+    $repo
+}
+
+export def get-commit [] {
+    assert false
+}
+
+export def goto-root [] {
+    let repo = init-repo-and-cd-into
+
+    mkdir init-repo-and-cd-into/bar/baz
+    cd init-repo-and-cd-into/bar/baz
 
     gm repo goto root
     assert equal (pwd) $repo
@@ -25,10 +31,7 @@ export def branches [] {
 }
 
 export def is-ancestor [] {
-    let repo = get-random-test-dir
-
-    ^git init $repo
-    cd $repo
+    init-repo-and-cd-into
 
     git commit --allow-empty --no-gpg-sign --message "init"
     git commit --allow-empty --no-gpg-sign --message "c1"

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -13,7 +13,12 @@ def --env init-repo-and-cd-into []: nothing -> path {
 }
 
 export def get-commit [] {
-    assert false
+    init-repo-and-cd-into
+
+    ^git checkout --orphan main
+    ^git commit --allow-empty --no-gpg-sign --message "init"
+
+    assert equal (gm repo get commit) (^git rev-parse HEAD)
 }
 
 export def goto-root [] {

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -25,7 +25,17 @@ export def branches [] {
 }
 
 export def is-ancestor [] {
-    assert false
+    let repo = get-random-test-dir
+
+    ^git init $repo
+    cd $repo
+
+    git commit --allow-empty --no-gpg-sign --message "init"
+    git commit --allow-empty --no-gpg-sign --message "c1"
+    git commit --allow-empty --no-gpg-sign --message "c2"
+
+    assert (gm repo is-ancestor HEAD^ HEAD)
+    assert not (gm repo is-ancestor HEAD HEAD^)
 }
 
 export def remote-list [] {


### PR DESCRIPTION
related to
- https://github.com/amtoine/nu-git-manager/issues/106

## description
this is an effort to
- [x] update the `nu-git-manager-sugar git` module
- [x] remove deprecated / useless commands
- [x] expose the meaningful ones as subcommands of `gm`
- [x] add tests when possible

### kept commands
- `get commit` -> `gm repo get commit`
- `root` -> `gm repo goto root`
- `branches` -> `gm repo branches`
- `is-ancestor` -> `gm repo is-ancestor`
- `remote list` -> `gm repo remote list`

### removed commands
- `operations`
- `compare`
- `lock clean`
- `remote add`
- `remote remove`
- `fixup`

### tests
a new `tests sugar git` module with
- `get-commit`
- `goto-root`
- `branches`
- `is-ancestor`
- `remote-list` 
