### PR TITLE
collect the output of `git rev-parse`

### DIFF
--- a/src/nu-git-manager-sugar/git.nu
+++ b/src/nu-git-manager-sugar/git.nu
@@ -11,8 +11,7 @@ use std log
 export def "gm repo get commit" [
     revision: string = "HEAD"  # the revision to get the hash of
 ]: nothing -> string {
-    # FIXME: this `str trim` sounds like a bug :thinking:
-    ^git rev-parse $revision | str trim
+    (^git rev-parse $revision)
 }
 
 def repo-root [] {


### PR DESCRIPTION
from the single commit
> this is because `git rev-parse` streams thus, because it returns a single line, Nushell needs to _collect_ the stream of raw input into a single `string`.
this can be done with `lines | get 0`, `str trim` or by wrapping the command in a subexpression.