### PR TITLE
fix `gm gh pr checkout`: user quit and no PR

### DIFF
--- a/src/nu-git-manager-sugar/github.nu
+++ b/src/nu-git-manager-sugar/github.nu
@@ -230,6 +230,7 @@ export def "gm gh pr checkout" [] {
         | input list --fuzzy
     if $res == null {
         log info "user chose to exit"
+        return
     }
 
     ^gh pr checkout $res.id

--- a/src/nu-git-manager-sugar/github.nu
+++ b/src/nu-git-manager-sugar/github.nu
@@ -224,10 +224,16 @@ export def "gm gh pr checkout" [] {
     }
 
     log debug $"pulling down list of pull requests for '($repo)'"
-    let res = gm gh query-api $"/repos/($repo)/pulls"
+    let prs = gm gh query-api $"/repos/($repo)/pulls"
         | select number user.login title
         | rename id author title
-        | input list --fuzzy
+    if ($prs | is-empty) {
+        log error $"repo '($repo)' does not have any PR to checkout"
+        log info "maybe the repo is not correct? you can try running `gh repo set-default` :)"
+        return
+    }
+
+    let res = $prs | input list --fuzzy
     if $res == null {
         log info "user chose to exit"
         return


### PR DESCRIPTION
related to
- https://github.com/amtoine/nu-git-manager/pull/31

## description
i found two bugs when using `gm gh pr checkout`
- in `nu-git-manager`, i pressed escape in `input list` and there was no early `return` => the command crashed on `$res.id`
- in `nushell`, my GitHub remote repo was incorrectly set to `amtoine/nushell` => the command crashed because the PR table was empty

this PR fixes those two bugs.