### PR TITLE
add type annotations to `toolkit.nu` and fix a bug

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -56,6 +56,8 @@ export def "run" [
         const CONFIG_FILE = ($GM_ENV.GIT_REPOS_HOME | path dirname | path join "config.nu")
         const ENV_FILE = ($GM_ENV.GIT_REPOS_HOME | path dirname | path join "env.nu")
 
+        mkdir ($CONFIG_FILE | path dirname)
+
         "$env.config = {show_banner: false}" | save --force $CONFIG_FILE
         "" | save --force $ENV_FILE
 

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -5,7 +5,7 @@
 export def "test" [
     pattern?: string = "" # the pattern a test name should match to run
     --verbose # show the output of each tests
-] {
+]: nothing -> nothing {
     use nupm
 
     if $verbose {
@@ -16,7 +16,7 @@ export def "test" [
 }
 
 # install `nu-git-manager` with Nupm
-export def "install" [] {
+export def "install" []: nothing -> nothing {
     use nupm
     nupm install --force --path (^git rev-parse --show-toplevel)
 }
@@ -36,7 +36,7 @@ export def "run" [
     code?: closure, # the code to run in the environment (required without `--interactive`)
     --clean, # raise this to clean the environment before running the code
     --interactive, # run interactively
-] {
+]: nothing -> nothing {
     const GM_ENV = {
         GIT_REPOS_HOME: ($nu.temp-path | path join "nu-git-manager/repos/"),
         GIT_REPOS_CACHE: ($nu.temp-path | path join "nu-git-manager/repos.cache"),


### PR DESCRIPTION
this PR adds some type annotations to the `toolkit.nu` and fixes a bug where running
```nushell
tk run --interactive
```
for the first time would give an error
```
Error:   × Permission denied
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nu-git-manager/toolkit.nu:58:1]
 58 │
 59 │         "$env.config = {show_banner: false}" | save --force $CONFIG_FILE
    ·                                                             ──────┬─────
    ·                                                                   ╰── No such file or directory (os error 2)
 60 │         "" | save --force $ENV_FILE
    ╰────
```