### PR TITLE
add `get-ignored-tests` to `toolkit.nu`

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -75,3 +75,14 @@ export def "run" [
         with-env $GM_ENV $code
     }
 }
+
+# TODO: documentation
+export def get-ignored-tests []: nothing -> table<file: string, test: string, reason: string> {
+    ^rg '^# ignored: ' tests/ -A 1
+        | lines
+        | split list "--"
+        | each {|it|
+            let reason = $it.0 | parse "{file}:# ignored: {reason}" | get reason.0
+            $it.1 | parse "{file}-def {test} [{rest}" | reject rest | insert reason $reason | first
+        }
+}

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -76,7 +76,7 @@ export def "run" [
     }
 }
 
-# TODO: documentation
+# will give a report about all the tests that are currently ignored
 export def get-ignored-tests []: nothing -> table<file: string, test: string, reason: string> {
     ^rg '^# ignored: ' tests/ -A 1
         | lines


### PR DESCRIPTION
this PR adds a new `get-ignored-tests` to the `toolkit.nu` to list all ignore tests in the repo

# example
the current set of ignored tests
```
#┬───────file───────┬──────────test───────────┬───────────reason────────────
0│tests/sugar/mod.nu│report                   │`nu_plugin_gstat` is required
1│tests/sugar/git.nu│branch-interactive-delete│interactive
2│tests/sugar/git.nu│branch-interactive-switch│interactive
─┴──────────────────┴─────────────────────────┴─────────────────────────────
```