### PR TITLE
better live environment in the toolkit

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -68,10 +68,12 @@ export def "run" [
         "$env.config = {show_banner: false}" | save --force $CONFIG_FILE
         "" | save --force $ENV_FILE
 
-        let imports = $sugar
-            | each { $"use ./src/nu-git-manager-sugar ($in) *" }
-            | prepend "use ./src/nu-git-manager *"
-            | str join "\n"
+        let sugar_imports = if $sugar != null {
+            $sugar | each { $"use ./src/nu-git-manager-sugar ($in) *" }
+        } else {
+            []
+        }
+        let imports = $sugar_imports | prepend "use ./src/nu-git-manager *" | str join "\n"
 
         let nu_args = [
             --env-config $ENV_FILE

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -42,6 +42,7 @@ export def "run" [
     code?: closure, # the code to run in the environment (required without `--interactive`)
     --clean, # raise this to clean the environment before running the code
     --interactive, # run interactively
+    --sugar: list<string>, # additional `sugar` modules to import
 ]: nothing -> nothing {
     const GM_ENV = {
         GIT_REPOS_HOME: ($nu.temp-path | path join "nu-git-manager/repos/"),
@@ -67,11 +68,13 @@ export def "run" [
         "$env.config = {show_banner: false}" | save --force $CONFIG_FILE
         "" | save --force $ENV_FILE
 
+        let sugar = $sugar | each { $"use ./src/nu-git-manager-sugar ($in) *" } | str join "; "
+
         with-env ($GM_ENV | merge {PROMPT_COMMAND: "NU-GIT-MANAGER"}) {
             ^$nu.current-exe [
                 --env-config $ENV_FILE
                 --config $CONFIG_FILE
-                --execute "use ./src/nu-git-manager *"
+                --execute $"use ./src/nu-git-manager *; ($sugar)"
             ]
         }
     } else {

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -32,6 +32,12 @@ export def "install" []: nothing -> nothing {
 #
 #     clean the environment before running the code
 #     > toolkit run --clean { gm clone https://github.com/amtoine/nu-git-manager --depth 1 }
+#
+#     run gm commands in an interactive shell
+#     > toolkit run --interactive
+#
+#     include more sugar commands in the interactive shell, e.g. Git and extra gm
+#     > toolkit run --interactive --sugar ["git", "extra"]
 export def "run" [
     code?: closure, # the code to run in the environment (required without `--interactive`)
     --clean, # raise this to clean the environment before running the code

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -71,7 +71,7 @@ export def "run" [
         let imports = $sugar
             | each { $"use ./src/nu-git-manager-sugar ($in) *" }
             | prepend "use ./src/nu-git-manager *"
-            | str join "; "
+            | str join "\n"
 
         let nu_args = [
             --env-config $ENV_FILE
@@ -82,7 +82,7 @@ export def "run" [
         if $res.exit_code != 0 {
             print $res.stderr
             error make --unspanned {
-                msg: "see above"
+                msg: $"`--sugar` \(($sugar)\) contains modules that are not part of `nu-git-manager-sugar`"
             }
         }
 


### PR DESCRIPTION
to `run --interactive` in `toolkit.nu`, this PR adds
- some examples
- `--sugar: list<string>` to import extra "sugar" modules