### PR TITLE
add `git-prompt` module

### DIFF
--- a/src/nu-git-manager-sugar/git-prompt.nu
+++ b/src/nu-git-manager-sugar/git-prompt.nu
@@ -217,6 +217,32 @@ def get-left-prompt [duration_threshold: duration]: nothing -> string {
     $segments | compact | str join " "
 }
 
+# setup the Git prompt of NGM
+#
+# the different sections of the prompt are the following, in order and separated by a single space:
+# - "admin_segment": shows if you are an admin of the session
+# - "pwd": shows the current working directory, in long form outside of a repo or with only the
+#     basename if inside a Git repo
+# - "git_branch_segment": if inside a Git repo, will show the current branch, the tag or the
+#     detached revision
+# - "git_action_segment": if inside a Git repo and performing a Git action, such as a MERGE or a
+#     REBASE, the prompt will show the stage of the action
+# - "duration_segment": if the last command took longer than the `--duration-threshold`, the prompt
+#     will show the exact duration
+# - "command_failed_segment": if the last command failed, the exit code will be shown
+# - "login_segment": shows if you are in a login session
+#
+# # Examples
+#     setup the prompt with 10sec of command duration and `> ` as the Vi indicator
+#     > export-env {
+#           use nu-git-manager-sugar git-prompt setup
+#           setup --duration-threshold 10sec --indicators {
+#               vi: {
+#                   insert: "> "
+#                   normal: "> "
+#               }
+#           }
+#       }
 export def --env setup [
     --indicators = $DEFAULT_PROMPT_INDICATORS,
     --duration-threshold: duration = 1sec  # the threshold above which the command duration is shown

--- a/src/nu-git-manager-sugar/git-prompt.nu
+++ b/src/nu-git-manager-sugar/git-prompt.nu
@@ -191,7 +191,7 @@ def get-left-prompt [duration_threshold: duration]: nothing -> string {
         null
     }
 
-    let cmd_duration = $"($env.CMD_DURATION_MS)ms" | into duration
+    let cmd_duration = $env.CMD_DURATION_MS | into int | $in * 1ms
     let duration_segment = if $cmd_duration > $duration_threshold {
         $cmd_duration | color "light_yellow"
     } else {

--- a/src/nu-git-manager-sugar/git-prompt.nu
+++ b/src/nu-git-manager-sugar/git-prompt.nu
@@ -3,6 +3,7 @@ const DEFAULT_PROMPT_INDICATORS = {
     vi: {insert: ": ", normal: "> "}
 }
 
+# TODO: write a test
 def simplify-path []: path -> string {
     str replace $nu.home-path "~" | str replace --regex '^/' "!/"
 }
@@ -50,6 +51,7 @@ def color [color]: string -> string {
 #     │ hash │ fa3c0651 │
 #     │ type │ detached │
 #     ╰──────┴──────────╯
+# TODO: write a test
 def get-revision [
     --short-hash: bool  # print the hash of a detached HEAD in short format
 ]: nothing -> record<name: string, hash: string, type: string> {
@@ -80,6 +82,7 @@ def get-revision [
 }
 
 # https://stackoverflow.com/questions/59603312/git-how-can-i-easily-tell-if-im-in-the-middle-of-a-rebase
+# TODO: write a test
 def git-action []: nothing -> string {
     let git_dir = ^git rev-parse --git-dir | path expand
 
@@ -120,6 +123,7 @@ def git-action []: nothing -> string {
     }
 }
 
+# TODO: write a test
 def get-left-prompt [duration_threshold: duration]: nothing -> string {
     let pwd = do {
         let is_git_repo = not (


### PR DESCRIPTION
should
- close #9 

## description
this prompt comes from `amtoine/scripts` in the `nu-scripts` package, module `shell_prompt`.

it can be used as
```nushell
use nu-git-manager-sugar git-prompt setup
setup --duration-threshold 10sec --indicators {
    vi: {
        insert: "> "
        normal: "> "
    }
}
```

> **Important**
> i did not add tests for this right now, only TODOs on all the commands i believe should be tested :wink: 