### PR TITLE
fix export use in the tests

### DIFF
--- a/tests/sugar/mod.nu
+++ b/tests/sugar/mod.nu
@@ -4,7 +4,7 @@ use ../common/import.nu ["assert imports"]
 
 const MODULE = "nu-git-manager-sugar"
 
-module imports {
+export module imports {
     export def main [] {
         assert imports $MODULE "" []
     }
@@ -38,8 +38,6 @@ module imports {
         ]
     }
 }
-
-export use imports
 
 # ignored: `nu_plugin_gstat` is required
 def report [] {


### PR DESCRIPTION
this is a minor refactor in the tests.
instead of doing
```nushell
module some-tests {
    ...
}
export use some-tests
```
it's possible to directly do
```nushell
export module some-tests {
    ...
}
```