### PR TITLE
REFACTOR

### DIFF
--- a/src/nu-git-manager-sugar/git/lib/lib.nu
+++ b/src/nu-git-manager-sugar/git/lib/lib.nu
@@ -1,3 +1,5 @@
+use ../../git/lib/style.nu [color]
+
 # give the revision of the repo you're in
 #
 # in the output, $.type is guaranteed to be one of

--- a/src/nu-git-manager-sugar/git/lib/prompt.nu
+++ b/src/nu-git-manager-sugar/git/lib/prompt.nu
@@ -1,11 +1,5 @@
-# TODO: write a test
-def simplify-path []: path -> string {
-    str replace $nu.home-path "~" | str replace --regex '^/' "!/"
-}
-
-def color [color]: string -> string {
-    $"(ansi $color)($in)(ansi reset)"
-}
+use ../../git/lib/lib.nu [get-revision, git-action]
+use ../../git/lib/style.nu [color, simplify-path]
 
 # TODO: write a test
 export def get-left-prompt [duration_threshold: duration]: nothing -> string {

--- a/src/nu-git-manager-sugar/git/lib/style.nu
+++ b/src/nu-git-manager-sugar/git/lib/style.nu
@@ -1,0 +1,7 @@
+export def simplify-path []: path -> string {
+    str replace $nu.home-path "~" | str replace --regex '^/' "!/"
+}
+
+export def color [color]: string -> string {
+    $"(ansi $color)($in)(ansi reset)"
+}

--- a/src/nu-git-manager-sugar/git/prompt.nu
+++ b/src/nu-git-manager-sugar/git/prompt.nu
@@ -1,4 +1,3 @@
-use ../git/lib/lib.nu [get-revision, git-action]
 use ../git/lib/prompt.nu [get-left-prompt]
 
 const DEFAULT_PROMPT_INDICATORS = {


### PR DESCRIPTION
related to
- https://github.com/amtoine/nu-git-manager/pull/122

## description
i was writing https://github.com/amtoine/nu-git-manager/pull/122 and i noticed the imports of `git prompt` where completely messed up :eyes: 

## reproduce
from the branch of #122, run `tk test prompt`
- before that change, i.e. on 1b36d96
```
Testing package /home/amtoine/documents/repos/github.com/amtoine/nu-git-manager
tests sugar git prompt build-left-prompt ... FAILURE
tests sugar git prompt repo-current-action ... FAILURE
tests sugar git prompt repo-revision ... SUCCESS

Test "tests sugar git prompt build-left-prompt" failed with exit code 1:
Error:   × todo

Test "tests sugar git prompt repo-current-action" failed with exit code 1:
Switched to a new branch 'main'
Switched to a new branch 'some'
Switched to a new branch 'other'
Error: nu::shell::external_command

  × External command failed
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nu-git-manager/src/nu-git-manager-sugar/git/lib/lib.nu:96:1]
 96 │         } else if (test-file "MERGE_HEAD") {
 97 │             "MERGING" | color dark_gray
    ·                         ──┬──
    ·                           ╰── did you mean 'nu-highlight'?
 98 │         } else if (test-file "CHERRY_PICK_HEAD") {
    ╰────
  help: No such file or directory (os error 2)

Ran 3 tests. 1 succeeded, 2 failed.
Error:   × some tests failed
```
- after that change, e.g. by merging the two branches together
```
Testing package /home/amtoine/documents/repos/github.com/amtoine/nu-git-manager
tests sugar git prompt build-left-prompt ... FAILURE
tests sugar git prompt repo-current-action ... SUCCESS
tests sugar git prompt repo-revision ... SUCCESS

Test "tests sugar git prompt build-left-prompt" failed with exit code 1:
Error:   × todo

Ran 3 tests. 2 succeeded, 1 failed.
Error:   × some tests failed
```