### PR TITLE
test imports exactly

### DIFF
--- a/tests/common/import.nu
+++ b/tests/common/import.nu
@@ -1,11 +1,16 @@
 export def "assert imports" [
-    module: string, submodule: string, expected: list<string>, --prefix: string = "gm "
+    module: string, submodule: string, expected: list<string>
 ] {
-    let src = $"
+    let before = ^$nu.current-exe --no-config-file --commands "
+        scope commands | get name
+    | to nuon
+    " | from nuon
+    let after = ^$nu.current-exe --no-config-file --commands $"
         use ./src/($module)/ ($submodule) *
-        scope commands | get name | where \($it | str starts-with '($prefix)'\) | to nuon
-    "
+        scope commands | get name
+    | to nuon" | from nuon
 
-    let actual = ^$nu.current-exe --no-config-file --commands $src | from nuon
-    assert equal $actual $expected
+    let imported = $after | where $it not-in $before
+
+    assert equal $imported $expected
 }

--- a/tests/gm.nu
+++ b/tests/gm.nu
@@ -337,6 +337,7 @@ export def store-cleaning [] {
 
 export def user-import [] {
     assert imports "nu-git-manager" "" [
+        "gm",
         "gm clean",
         "gm clone",
         "gm list",

--- a/tests/sugar/mod.nu
+++ b/tests/sugar/mod.nu
@@ -5,10 +5,6 @@ use ../common/import.nu ["assert imports"]
 const MODULE = "nu-git-manager-sugar"
 
 export module imports {
-    export def main [] {
-        assert imports $MODULE "" []
-    }
-
     export def extra [] {
         assert imports $MODULE "extra" [ "gm report" ]
     }
@@ -26,6 +22,7 @@ export module imports {
             "gm repo ls",
             "gm repo remote list",
             "gm repo switch",
+            "prompt setup",
         ]
     }
 


### PR DESCRIPTION
this PR ensures that the import tests are _strong_.

by _strong_, i mean that now, they compare the list of commands in scope before and after the `use` of a given module.
the diff, i.e. the new commands in scope, should be exactly the commands from the module.
the import tests don't rely on a prefix anymore.