### PR TITLE
trim PR title when too large for terminal in `gm gh pr checkout`

### DIFF
--- a/src/nu-git-manager-sugar/github.nu
+++ b/src/nu-git-manager-sugar/github.nu
@@ -244,8 +244,8 @@ export def "gm gh pr checkout" [] {
         | update author { fill --alignment right --character ' ' --width $width.author }
         | update id { fill --alignment right --character ' ' --width $width.id }
         | update title { fill --alignment left --character ' ' --width $width.title }
-        | each {|it|
-            $"($in.author) \(($in.id)\): ($it.title)" | str substring ..((term size).columns - 2)
+        | each {
+            $"($in.author) \(($in.id)\): ($in.title)" | str substring ..((term size).columns - 2)
         }
 
     let res = $prs | input list --fuzzy

--- a/src/nu-git-manager-sugar/github.nu
+++ b/src/nu-git-manager-sugar/github.nu
@@ -233,6 +233,10 @@ export def "gm gh pr checkout" [] {
         return
     }
 
+    # NOTE: `input list` has trouble with large inputs...
+    # this part of the command makes sure each line fits in the terminal width nicely.
+    #
+    # related to https://github.com/nushell/nushell/issues/11245
     let width = $prs
         | each { {
             author: ($in.author | str length),


### PR DESCRIPTION
`input list` has trouble
- scrolling when one line is too large
- treating ANSI sequences (they match, e.g the `m` in `\0[m`)

this PR computes custom lines that are trimmed to the size of the terminal and don't use ANSI coloring :thinking: 

## test it
- run
```nushell
tk run --interactive --sugar ["github"]
```
- go to a directory with remote PR, e.g. `nushell/nushell`
- run
```nushell
gm gh pr checkout
```