### PR TITLE
fix `gm repo branches` failing on checked out branch

### DIFF
--- a/src/nu-git-manager-sugar/git/mod.nu
+++ b/src/nu-git-manager-sugar/git/mod.nu
@@ -72,6 +72,11 @@ export def "gm repo branches" [
         }
 
         for branch in $dangling_branches.branch {
+            if $branch == (^git branch --show-current) {
+                log warning $"($branch) is currently checked out and cannot be deleted"
+                continue
+            }
+
             log info $"deleting branch `($branch)`"
             ^git branch --quiet --delete --force $branch
         }

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -71,6 +71,20 @@ export def branches [] {
     clean $repo
 }
 
+export def branches-checked-out [] {
+    let repo = init-repo-and-cd-into
+
+    commit "init"
+
+    ^git branch bar
+    ^git branch foo
+    ^git checkout bar
+
+    gm repo branches --clean
+
+    clean $repo
+}
+
 export def is-ancestor [] {
     let repo = init-repo-and-cd-into
 

--- a/tests/sugar/git.nu
+++ b/tests/sugar/git.nu
@@ -81,6 +81,7 @@ export def branches-checked-out [] {
     ^git checkout bar
 
     gm repo branches --clean
+    assert equal (gm repo branches) [{branch: bar, remotes: []}, ]
 
     clean $repo
 }


### PR DESCRIPTION
should
- close #130 

## changelog
- add a test that should pass, taken from #130 
- fix the `gm repo branches` command