### PR TITLE
add `--personal` to `run` in `toolkit.nu`

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -59,11 +59,12 @@ export def "run" [
     if $clean {
         if $personal {
             let prompt = $"You are about to (ansi red_bold)clean your personal store of repositories(ansi reset) :o (ansi yellow_bold)Are you sure?(ansi reset)"
-            match (["no", "yes"] | input  list $prompt) {
+            match (["no", "yes"] | input list $prompt) {
                 null | "no" => { return },
                 "yes" => {},
             }
         }
+
         with-env $gm_env {
             gm status | select root.path cache.path | values | each {
                 if ($in | path exists) {

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -56,7 +56,7 @@ export def "run" [
         $GM_ENV
     }
 
-    if $clean {
+    if $clean { do {
         if $personal {
             let prompt = $"You are about to (ansi red_bold)clean your personal store of repositories(ansi reset) :o (ansi yellow_bold)Are you sure?(ansi reset)"
             match (["no", "yes"] | input list $prompt) {
@@ -72,7 +72,7 @@ export def "run" [
                 }
             }
         }
-    }
+    } }
 
     if $interactive {
         let config_file = $GM_ENV.GIT_REPOS_HOME | path dirname | path join "config.nu"

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -75,7 +75,7 @@ export def "run" [
     }
 
     if $interactive {
-        let config_file = $env.GIT_REPOS_HOME | path dirname | path join "config.nu"
+        let config_file = $GM_ENV.GIT_REPOS_HOME | path dirname | path join "config.nu"
         let env_file = if $personal {
             $nu.env-path
         } else {


### PR DESCRIPTION
the idea is to allow testing new commands in the real store of repos.

## example
```nushell
tk run --interactive --personal --sugar ["extra", "github"]
```
will run the currently checked out revision
- _interactively_, i.e. opening a REPL
- _personally_, i.e. in the store of repos of the user instead of a new blank one in `$nu.temp-path`
- with some _sugar_, i.e. with the `gm` commands from `extra` and `github`

> **Important**
> using both `--personal` and `--clean` will pull up a prompt with all defaults set to `false` to make sure the user is conscious of what is about to happen... deletion of all their repos :scream: 
> - in case they explicitely answer `yes`, the store will be emptied
> - in case they answer `no`, the cleaning step will be skipped and the rest will run as if `--clean` was not raised