### PR TITLE
add a "Git changes" segment to the prompt

### DIFF
--- a/src/nu-git-manager-sugar/git/lib/lib.nu
+++ b/src/nu-git-manager-sugar/git/lib/lib.nu
@@ -111,3 +111,13 @@ export def git-action []: nothing -> string {
     }
 }
 
+export def get-status [
+    repo: path, # the path to the repo
+]: nothing -> record<staged: list<string>, unstaged: list<string>, untracked: list<string>> {
+    let status = ^git -C $repo status --short | lines
+    {
+        staged: ($status | parse --regex '^\w. (?<file>.*)' | get file),
+        unstaged: ($status | parse --regex '^.\w (?<file>.*)' | get file),
+        untracked: ($status | parse --regex '^\?\? (?<file>.*)' | get file),
+    }
+}

--- a/src/nu-git-manager-sugar/git/lib/prompt.nu
+++ b/src/nu-git-manager-sugar/git/lib/prompt.nu
@@ -1,4 +1,4 @@
-use ../../git/lib/lib.nu [get-revision, git-action]
+use ../../git/lib/lib.nu [get-revision, git-action, get-status]
 use ../../git/lib/style.nu [color, simplify-path]
 
 # TODO: write a test
@@ -57,6 +57,25 @@ export def get-left-prompt [duration_threshold: duration]: nothing -> string {
         null
     }
 
+    let git_changes_segment = if $is_git_repo {
+        let status = get-status .
+
+        let markers = [
+            (if not ($status.staged | is-empty) { "_" }),
+            (if not ($status.unstaged | is-empty) { "!" }),
+            (if not ($status.untracked | is-empty) { "?" }),
+        ]
+        let markers = $markers | compact | str join ""
+
+        if $markers == "" {
+            null
+        } else {
+            $"[($markers)]" | color default_dimmed
+        }
+    } else {
+        null
+    }
+
     let admin_segment = if (is-admin) {
         "!!" | color "red_bold"
     } else {
@@ -87,6 +106,7 @@ export def get-left-prompt [duration_threshold: duration]: nothing -> string {
         $pwd,
         $git_branch_segment,
         $git_action_segment,
+        $git_changes_segment,
         $duration_segment,
         $command_failed_segment,
         $login_segment,

--- a/src/nu-git-manager-sugar/git/mod.nu
+++ b/src/nu-git-manager-sugar/git/mod.nu
@@ -234,7 +234,7 @@ export def "gm repo switch" []: nothing -> nothing {
 # get some information about a repo
 export def "gm repo ls" [
     repo?: path, # the path to the repo (defaults to `.`)
-]: nothing -> record<path: path, name: string, staged: int, unstaged: int, untracked: int, last_commit: record<date: datetime, title: string, hash: string>, branch: string> {
+]: nothing -> record<path: path, name: string, staged: list<string>, unstaged: list<string>, untracked: list<string>, last_commit: record<date: datetime, title: string, hash: string>, branch: string> {
     let repo = $repo | default (pwd)
     let status = get-status $repo
 

--- a/src/nu-git-manager-sugar/git/mod.nu
+++ b/src/nu-git-manager-sugar/git/mod.nu
@@ -1,5 +1,7 @@
 use std log
 
+use ../git/lib/lib.nu [get-status]
+
 # get the commit hash of any revision
 #
 # # Examples
@@ -234,7 +236,7 @@ export def "gm repo ls" [
     repo?: path, # the path to the repo (defaults to `.`)
 ]: nothing -> record<path: path, name: string, staged: int, unstaged: int, untracked: int, last_commit: record<date: datetime, title: string, hash: string>, branch: string> {
     let repo = $repo | default (pwd)
-    let status = ^git -C $repo status --short | lines
+    let status = get-status $repo
 
     let last_commit = if (do --ignore-errors { git -C $repo log -1 } | complete).exit_code == 0 { {
         date: (^git -C $repo log -1 --format=%cd | into datetime),
@@ -248,9 +250,9 @@ export def "gm repo ls" [
         # FIXME: should be using `path sanitize` defined in `nu-git-manager`
         path: ($repo | str replace --regex '^.:' '' | str replace --all '\' '/'),
         name: ($repo | path basename),
-        staged: ($status | parse --regex '^\w. (?<file>.*)' | get file),
-        unstaged: ($status | parse --regex '^.\w (?<file>.*)' | get file),
-        untracked: ($status | parse --regex '^\?\? (?<file>.*)' | get file),
+        staged: $status.staged,
+        unstaged: $status.unstaged,
+        untracked: $status.untracked,
         last_commit: $last_commit,
         branch: (^git -C $repo branch --show-current),
     }


### PR DESCRIPTION
wait for
- #122 (to include a test and make sure the changes appear in the prompt)

## changelog
- refactor the short Git status into `git/lib get-status`
- adds a segment containing Git changes

## details
- if there are no changes in the index, the prompt won't add anything.
- if there are changes, they will appear after the `(branch:commit)` segment inside `[...]`
- in order
  - staged changes will show up as one `_`
  - unstaged changes will show up as one `!`
  - untracked changes will show up as one `?`