### PR TITLE
use the toolkit in the CI

### DIFF
--- a/.github/workflows/nupm-tests.yml
+++ b/.github/workflows/nupm-tests.yml
@@ -68,5 +68,11 @@ jobs:
 
       - name: Run the tests
         run: |
-          use ${{ steps.nu-setup.outputs.nupm_path }}
-          nupm test --show-stdout
+          # NOTE: required for `use nupm` to work inside `toolkit test`
+          "$env.NU_LIB_DIRS = [ (${{ steps.nu-setup.outputs.nupm_path }} | path dirname) ]"
+            | save --force /tmp/env.nu
+          # NOTE: required for `use toolkit.nu` to work
+          nu --env-config /tmp/env.nu --commands "
+            use toolkit.nu
+            toolkit test --verbose
+          "


### PR DESCRIPTION
this PR uses the `toolkit` module and its `test` command to run the tests in the CI, such that we have only one point to change to modify how the tests run.