### PR TITLE
bump to 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
   tests:
     uses: ./.github/workflows/nupm-tests.yml
     with:
-      nu_version: "0.87.0"
+      nu_version: "0.88.0"
       nupm_revision: "f7c0843f4d667194beae468614a46cc8d72cc5db"

--- a/package.nuon
+++ b/package.nuon
@@ -1,6 +1,6 @@
 {
     name: "nu-git-manager"
-    version: 0.3.0
+    version: 0.4.0
     description: "A collection of Nushell tools to manage `git` repositories."
     documentation: "https://github.com/amtoine/nu-git-manager/blob/main/README.md"
     maintainers: [
@@ -9,7 +9,7 @@
     ]
     license: "https://github.com/amtoine/nu-git-manager/blob/main/LICENSE"
     dependencies: {
-        nushell: 0.80.1+
+        nushell: 0.88.0
         git: 2.40.1
         optionals: {
             "sugar gh": {

--- a/src/nu-git-manager-sugar/github.nu
+++ b/src/nu-git-manager-sugar/github.nu
@@ -182,11 +182,7 @@ export def "gm gh query-releases" [
     --page-size: int = 100 # the size of each page
     --no-gh # force to use `http get` instead of `gh`
 ]: nothing -> table<url: string, assets_url: string, upload_url: string, html_url: string, id: int, author: record<login: string, id: int, node_id: string, avatar_url: string, gravatar_id: string, url: string, html_url: string, followers_url: string, following_url: string, gists_url: string, starred_url: string, subscriptions_url: string, organizations_url: string, repos_url: string, events_url: string, received_events_url: string, type: string, site_admin: bool>, node_id: string, tag_name: string, target_commitish: string, name: string, draft: bool, prerelease: bool, created_at: string, published_at: string, assets: list<any>, tarball_url: string, zipball_url: string, body: string, reactions: record<url: string, total_count: int, +1: int, -1: int, laugh: int, hooray: int, confused: int, heart: int, rocket: int, eyes: int>, mentions_count: int> {
-    if $no_gh {
-        gm gh query-api $"/repos/($repo)/releases" --page-size $page_size --no-gh
-    } else {
-        gm gh query-api $"/repos/($repo)/releases" --page-size $page_size
-    }
+    gm gh query-api $"/repos/($repo)/releases" --page-size $page_size --no-gh=$no_gh
 }
 
 # get information about a GitHub user
@@ -198,11 +194,7 @@ export def "gm gh query-user" [
     user: string # the user to query information about
     --no-gh # force to use `http get` instead of `gh`
 ]: nothing -> record<login: string, id: int, node_id: string, avatar_url: string, gravatar_id: string, url: string, html_url: string, followers_url: string, following_url: string, gists_url: string, starred_url: string, subscriptions_url: string, organizations_url: string, repos_url: string, events_url: string, received_events_url: string, type: string, site_admin: bool, name: string, company: string, blog: string, location: string, email: nothing, hireable: nothing, bio: string, twitter_username: nothing, public_repos: int, public_gists: int, followers: int, following: int, created_at: string, updated_at: string> {
-    if $no_gh {
-        gm gh query-api $"/users/($user)" --no-paginate --no-gh
-    } else {
-        gm gh query-api $"/users/($user)" --no-paginate
-    }
+    gm gh query-api $"/users/($user)" --no-paginate --no-gh=$no_gh
 }
 
 # checkout one of the repo's PR interactively


### PR DESCRIPTION
- rebase the changes from nightly
- bump NGM to `0.4.0` and Nushell to `0.88.0`

> **Note**
> ```nushell
> git diff nightly
> ```
> correctly gives
> ```diff
> diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
> index 2161e01..5263c02 100644
> --- a/.github/workflows/ci.yml
> +++ b/.github/workflows/ci.yml
> @@ -13,5 +13,5 @@ jobs:
>    tests:
>      uses: ./.github/workflows/nupm-tests.yml
>      with:
> -      nu_version: "0.87.0"
> +      nu_version: "0.88.0"
>        nupm_revision: "f7c0843f4d667194beae468614a46cc8d72cc5db"
> diff --git a/package.nuon b/package.nuon
> index e963dbc..3886fdf 100644
> --- a/package.nuon
> +++ b/package.nuon
> @@ -1,6 +1,6 @@
>  {
>      name: "nu-git-manager"
> -    version: 0.3.0
> +    version: 0.4.0
>      description: "A collection of Nushell tools to manage `git` repositories."
>      documentation: "https://github.com/amtoine/nu-git-manager/blob/main/README.md"
>      maintainers: [
> @@ -9,7 +9,7 @@
>      ]
>      license: "https://github.com/amtoine/nu-git-manager/blob/main/LICENSE"
>      dependencies: {
> -        nushell: 0.80.1+
> +        nushell: 0.88.0
>          git: 2.40.1
>          optionals: {
>              "sugar gh": {
> ```
