### PR TITLE
use `github.base_ref` to get the target branch in the CI

### DIFF
--- a/.github/workflows/nupm-tests.yml
+++ b/.github/workflows/nupm-tests.yml
@@ -56,8 +56,8 @@ jobs:
         uses: amtoine/setup-nupm-action@0.1.1
         id: "nu-setup"
         with:
-          nu_version: ${{github.ref == 'refs/heads/nightly' && 'nightly' || inputs.nu_version}}
-          nupm_revision: ${{github.ref == 'refs/heads/nightly' && 'main' || inputs.nupm_revision}}
+          nu_version: ${{github.base_ref == 'nightly' && 'nightly' || inputs.nu_version}}
+          nupm_revision: ${{github.base_ref == 'nightly' && 'main' || inputs.nupm_revision}}
 
       - name: Set up Git
         shell: bash


### PR DESCRIPTION
`github.ref` would give something like `refs/pull/xxx/merge` whereas `github.base_ref` would give `nightly` or `main` depending on the target branch.

> see [the doc](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
> > `GITHUB_BASE_REF`
> > The name of the base ref or target branch of the pull request in a workflow run. This is only set when the event that triggers a workflow run is either `pull_request` or `pull_request_target`. For example, `main`.