### PR TITLE
remove quotes from `NU_VERSION` and `NUPM_REVISION`

### DIFF
--- a/.github/workflows/nupm-tests.yml
+++ b/.github/workflows/nupm-tests.yml
@@ -48,11 +48,11 @@ jobs:
           echo "ref: ${{github.ref}}"
 
           if [[ '${{ github.base_ref }}' == 'nightly' ]]; then
-            echo "NU_VERSION='nightly'" >> $GITHUB_ENV
-            echo "NUPM_REVISION='main'" >> $GITHUB_ENV
+            echo "NU_VERSION=nightly" >> $GITHUB_ENV
+            echo "NUPM_REVISION=main" >> $GITHUB_ENV
           elif [[ '${{ github.ref }}' == 'refs/heads/nightly' ]]; then
-            echo "NU_VERSION='nightly'" >> $GITHUB_ENV
-            echo "NUPM_REVISION='main'" >> $GITHUB_ENV
+            echo "NU_VERSION=nightly" >> $GITHUB_ENV
+            echo "NUPM_REVISION=main" >> $GITHUB_ENV
           else
             echo "NU_VERSION=${{ inputs.nu_version }}" >> $GITHUB_ENV
             echo "NUPM_REVISION=${{ inputs.nupm_revision }}" >> $GITHUB_ENV


### PR DESCRIPTION
looking at the logs, it appears there might be extra quotes around the Nushell version, i.e. `'nightly'` instead of just `nightly`.
let's try removing them.