### PR TITLE
fix module exports

### DIFF
--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
@@ -1,0 +1,3 @@
+export module extra.nu
+export module git
+export module github.nu

--- a/src/nu-git-manager-sugar/mod.nu
+++ b/src/nu-git-manager-sugar/mod.nu
@@ -1,3 +1,0 @@
-export module extra.nu
-export module git
-export module github.nu

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -112,11 +112,13 @@ export def "run" [
         }
 
         let sugar_imports = if $sugar != null {
-            $sugar | each { $"use ./src/nu-git-manager-sugar ($in) *" }
+            $sugar | each { $"use ./pkgs/nu-git-manager-sugar/nu-git-manager-sugar ($in) *" }
         } else {
             []
         }
-        let imports = $sugar_imports | prepend "use ./src/nu-git-manager *" | str join "\n"
+        let imports = $sugar_imports
+            | prepend "use ./pkgs/nu-git-manager/nu-git-manager *"
+            | str join "\n"
 
         let nu_args = [
             --env-config $env_file


### PR DESCRIPTION
follow-up to
- https://github.com/amtoine/nu-git-manager/pull/134

## description
- `toolkit.nu` still contained `./src/`
- there was a bad `./src/nu-git-manager/mod.nu` introduced by https://github.com/amtoine/nu-git-manager/pull/134