### PR TITLE
check the documentation in PRs against `nightly`

### DIFF
--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -2,7 +2,7 @@ name: Checking the documentation
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, nightly]
     types: [opened, synchronize, reopened]
   push:
     branches:

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@v3
 
-      - uses: hustcer/setup-nu@v3.7
+      - uses: hustcer/setup-nu@v3.8
         with:
           version: "0.88.1"
 

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -10,7 +10,7 @@ on:
       - nightly
 
 jobs:
-  check-merge:
+  check-documentation:
     runs-on: ubuntu-latest
     steps:
       - name: Checking out repository

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: hustcer/setup-nu@v3.7
         with:
-          version: "0.87.0"
+          version: "0.88.1"
 
       - name: Check the documentation
         shell: nu {0}


### PR DESCRIPTION
the goal is to avoid https://github.com/amtoine/nu-git-manager/actions/runs/7247572612/job/19741768887 :eyes: 

this PR also
- fixes the name of the job from `check-merge` to `check-documentation`
- bumps the version of Nushell to `0.88.1`
- bumps the version of `hustcer/setup-nu` to `3.8`