### PR TITLE
dispatch the documentation CI

### DIFF
--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
 
+defaults:
+  run:
+    shell: nu {0}
+
 jobs:
   check-documentation:
     runs-on: ubuntu-latest
@@ -27,7 +31,6 @@ jobs:
           version: ${{ inputs.nu_version }}
 
       - name: Check the documentation
-        shell: nu {0}
         run: |
           nu --commands $"
             use ($env.PWD)/toolkit.nu

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -1,13 +1,19 @@
 name: Checking the documentation
 
 on:
-  pull_request:
-    branches: [main, nightly]
-    types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - main
-      - nightly
+  workflow_dispatch:
+    inputs:
+      nu_version:
+        description: "A semver, e.g. `0.12.3`, or `nightly` for the latest revision of Nushell."
+        required: true
+        type: string
+
+  workflow_call:
+    inputs:
+      nu_version:
+        description: "A semver, e.g. `0.12.3`, or `nightly` for the latest revision of Nushell."
+        required: true
+        type: string
 
 jobs:
   check-documentation:
@@ -18,7 +24,7 @@ jobs:
 
       - uses: hustcer/setup-nu@v3.8
         with:
-          version: "nightly"
+          version: ${{ inputs.nu_version }}
 
       - name: Check the documentation
         shell: nu {0}

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -26,9 +26,23 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@v3
 
+      - name: Setup Nushell version
+        shell: bash
+        run: |
+          echo "target: ${{github.base_ref}}"
+          echo "ref: ${{github.ref}}"
+
+          if [[ '${{ github.base_ref }}' == 'nightly' ]]; then
+            echo "NU_VERSION=nightly" >> $GITHUB_ENV
+          elif [[ '${{ github.ref }}' == 'refs/heads/nightly' ]]; then
+            echo "NU_VERSION=nightly" >> $GITHUB_ENV
+          else
+            echo "NU_VERSION=${{ inputs.nu_version }}" >> $GITHUB_ENV
+          fi
+
       - uses: hustcer/setup-nu@v3.8
         with:
-          version: ${{ inputs.nu_version }}
+          version: ${{ env.NU_VERSION }}
 
       - name: Check the documentation
         run: |

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: hustcer/setup-nu@v3.8
         with:
-          version: "0.88.1"
+          version: "nightly"
 
       - name: Check the documentation
         shell: nu {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,8 @@ jobs:
     with:
       nu_version: "0.88.1"
       nupm_revision: "6a9618fa21453bca4000ac33707b7aace0da35c7"
+
+  documentation:
+    uses: ./.github/workflows/check-documentation.yml
+    with:
+      nu_version: "0.88.1"


### PR DESCRIPTION
the documentation workflow cannot run on `0.88.1` always...

this PR
- refactors it as a dispatchable workflow to call it from the main `ci.yml`
- defaults to `nightly` Nushell builds when on `nightly`

> **Note**
> i was able to run a full job with
> ```nushell
> gh workflow run check-documentation.yml -r test-nightly-ci -f nu_version=nightly
> ```