### PR TITLE
remove deprecated `--switch: bool`

### DIFF
--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/lib/git.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/lib/git.nu
@@ -40,7 +40,7 @@ use style.nu [color]
 #     │ type │ detached │
 #     ╰──────┴──────────╯
 export def get-revision [
-    --short-hash: bool  # print the hash of a detached HEAD in short format
+    --short-hash  # print the hash of a detached HEAD in short format
 ]: nothing -> record<name: string, hash: string, type: string> {
     let tag = do -i {
         ^git describe HEAD --tags

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/lib/prompt.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/lib/prompt.nu
@@ -31,7 +31,7 @@ export def get-left-prompt [duration_threshold: duration]: nothing -> string {
     }
 
     let git_branch_segment = if $is_git_repo {
-        let revision = get-revision --short-hash true
+        let revision = get-revision --short-hash
         let pretty_branch_tokens = match $revision.type {
             "branch" => [
                 ($revision.name | color {fg: "yellow", attr: "ub"}),

--- a/pkgs/nu-git-manager-sugar/tests/git.nu
+++ b/pkgs/nu-git-manager-sugar/tests/git.nu
@@ -365,7 +365,7 @@ export module prompt {
     ]
 
     def "assert revision" [expected: record] {
-        let actual = get-revision --short-hash true
+        let actual = get-revision --short-hash
         assert equal $actual $expected
     }
 


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/11365

## description
this PR will suppress the deprecation warning from https://github.com/nushell/nushell/pull/11365 which is deprecating `: bool` annotations for switches