### PR TITLE
fix `gm repo branches clean` when HEAD is detached

### DIFF
--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
@@ -69,7 +69,10 @@ export def --env "gm repo goto root" []: nothing -> nothing {
 export def "gm repo branches" [
     --clean  # clean all dangling branches
 ]: nothing -> table<branch: string, remotes: list<string>> {
-    let local_branches = ^git branch --list | lines | str replace --regex '..' ""
+    let local_branches = ^git branch --list
+        | lines
+        | find --invert --regex '\(HEAD detached at .*\)'
+        | str replace --regex '..' ""
     let remote_branches = ^git branch --remotes
         | lines
         | str trim

--- a/pkgs/nu-git-manager-sugar/tests/git.nu
+++ b/pkgs/nu-git-manager-sugar/tests/git.nu
@@ -86,6 +86,21 @@ export def branches-checked-out [] {
     clean $repo
 }
 
+export def branches-detached [] {
+    let repo = init-repo-and-cd-into
+
+    let hash = commit "init" | first
+
+    ^git branch bar
+    ^git branch foo
+    ^git checkout $hash
+
+    gm repo branches --clean
+    assert equal (gm repo branches) []
+
+    clean $repo
+}
+
 export def is-ancestor [] {
     let repo = init-repo-and-cd-into
 


### PR DESCRIPTION
- add a test that should pass
- fix the command when `HEAD` is detached