### PR TITLE
checkout back when good or bad are invalid in `gm repo bisect`

### DIFF
--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
@@ -404,14 +404,14 @@ export def "gm repo bisect" [
     if not $no_check {
         print $"checking that ($good) is good..."
         ^git checkout $good
-        let res = try {
+        let is_good = try {
              do $test
             true
          } catch {
             false
         }
         ^git checkout -
-        if not $res {
+        if not $is_good {
             throw-error {
                 msg: "invalid_good_revision",
                 text: "not a good revision",
@@ -421,14 +421,14 @@ export def "gm repo bisect" [
 
         print $"checking that ($bad) is bad..."
         ^git checkout $bad
-        let res = try {
+        let is_good = try {
             do $test
             true
         } catch {
             false
         }
         ^git checkout -
-        if $res {
+        if $is_good {
             throw-error {
                 msg: "invalid_bad_revision",
                 text: "not a bad revision",

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
@@ -404,9 +404,14 @@ export def "gm repo bisect" [
     if not $no_check {
         print $"checking that ($good) is good..."
         ^git checkout $good
-        try {
-            do $test
-        } catch {
+        let res = try {
+             do $test
+            true
+         } catch {
+            false
+        }
+        ^git checkout -
+        if not $res {
             throw-error {
                 msg: "invalid_good_revision",
                 text: "not a good revision",
@@ -422,6 +427,7 @@ export def "gm repo bisect" [
         } catch {
             false
         }
+        ^git checkout -
         if $res {
             throw-error {
                 msg: "invalid_bad_revision",


### PR DESCRIPTION
this PR makes sure the user get back to where they were before running `gm repo bisect`, i.e.
- when the `--good` revision is not _good_
- when the `--bad` revision is not _bad_
- when the bisect runs properly, it should start on the same revision as before the _good_ / _bad_ checks