### PR TITLE
define a Nupm workspace

### DIFF
--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,0 +1,5 @@
+{
+    workspace: [
+        "pkgs/nu-git-manager", "pkgs/nu-git-manager-sugar"
+    ]
+}

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -2,7 +2,10 @@ use std repeat
 
 # NOTE: this will likely get replaced by Nupm workspaces in the future
 def list-modules-of-workspace []: nothing -> list<string> {
-    ls pkgs/**/nupm.nuon
+    open nupm.nuon
+        | get workspace
+        | each { path join "nupm.nuon" }
+        | wrap name
         | insert pkg {|it| open $it.name | get name }
         | each {|it| $it.name | path dirname | path join $it.pkg }
 }


### PR DESCRIPTION
use a top-level `nupm.nuon` to read the list of packages instead of hardcoding it inside `toolkit.nu`.

there is no support for workspaces in Nupm yet, but i prefer moving the list of packages to another file already, even if the format might likely change in the future.