### PR TITLE
give an error when removing a repo the user is in

### DIFF
--- a/docs/nu-git-manager/gm-clean.md
+++ b/docs/nu-git-manager/gm-clean.md
@@ -1,4 +1,4 @@
-# `gm clean` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L560))
+# `gm clean` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L567))
 clean the store
 
 this command will mainly remove empty directory recursively.

--- a/docs/nu-git-manager/gm-squash-forks.md
+++ b/docs/nu-git-manager/gm-squash-forks.md
@@ -1,4 +1,4 @@
-# `gm squash-forks` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L483))
+# `gm squash-forks` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L490))
 squash multi-directory forks into a single repo
 
 Here, two forks are defined as *two non-grafted repositories that share the same initial commit,

--- a/pkgs/nu-git-manager/nu-git-manager/mod.nu
+++ b/pkgs/nu-git-manager/nu-git-manager/mod.nu
@@ -431,6 +431,13 @@ export def "gm remove" [
 
     let repo_to_remove = $root | path join $repo_to_remove
 
+    # FIXME: this should be possible with `path relative-to`
+    # related to https://github.com/nushell/nushell/issues/10370
+    if (pwd | path expand | str starts-with $repo_to_remove) {
+        log error "cannot remove the repo because you are inside it"
+        return
+    }
+
     rm --recursive --force --verbose $repo_to_remove
 
     let cache_file = get-repo-store-cache-path


### PR DESCRIPTION
should close #179 

the new error is
```
2024-02-06T17:22:23.959|ERR|cannot remove the repo because you are inside it
```
when trying to remove a repo the user is currently in.