### PR TITLE
add a `gm version` command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,7 +56,7 @@ body:
     id: config
     attributes:
       label: Configuration
-      description: "Please run `version | transpose key value | to md --pretty` and paste the output to show OS, features, etc."
+      description: "Please run `version | transpose key value | to md --pretty` and `gm version | transpose key value | to md --pretty` and paste their outputs to show OS, features, etc."
       placeholder: |
         > version | transpose key value | to md --pretty
         | key                | value                                                                                                                                                                   |
@@ -70,6 +70,14 @@ body:
         | build_rust_channel | release                                                                                                                                                                 |
         | features           | clipboard-cli, ctrlc, dataframe, default, rustyline, term, trash, uuid, which, zip                                                                                      |
         | installed_plugins  | binaryview, chart bar, chart line, fetch, from bson, from sqlite, inc, match, post, ps, query json, s3, selector, start, sys, textview, to bson, to sqlite, tree, xpath |
+
+        > gm version | transpose key value | to md --pretty
+        | key     | value                                    |
+        | ------- | ---------------------------------------- |
+        | version | 0.6.0+0                                  |
+        | branch  | main                                     |
+        | commit  | 763f7695605c792fce99f7c6767f285584802ea8 |
+        | date    | Thu, 08 Feb 2024 19:45:14 +0100          |
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ it provides two main modules:
 ```shell
 git clone https://github.com/amtoine/nu-git-manager
 ```
-- activate the `nupm` module with `use nupm`
-- install the `nu-git-manager` package
+- activate the `toolkit` module with `use toolkit.nu`
+- install the `nu-git-manager` and `nu-git-manager-sugar` packages
 ```nushell
-nupm install --path --force pkgs/nu-git-manager
+toolkit install
+```
+- verify the installation after restarting Nushell
+```nushell
+gm version
 ```
 
 > **Note**

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -47,6 +47,25 @@ export def "install" []: nothing -> nothing {
 
         null
     "
+
+    let mod = $env.NUPM_HOME | path join "modules" "nu-git-manager" "mod.nu"
+    let v = (open pkgs/nu-git-manager/nupm.nuon).version
+    let n = ^git describe | parse "{v}-{n}-{r}" | into record | get n? | default 0
+    let version_cmd = [
+         "export def \"gm version\" []: nothing -> record<version: string, branch: string, commit: string, date: datetime> {",
+         "    {",
+        $"        version: \"($v)+($n)\",",
+        $"        branch: \"(^git branch --show-current)\",",
+        $"        commit: \"(^git rev-parse HEAD)\",",
+        $"        date: \((date now | to nuon)\),",
+         "    }",
+         "}",
+    ]
+
+    "\n" | save --append $mod
+    $version_cmd | str join "\n" | save --append $mod
+
+    null
 }
 
 # run some code inside an isolated environment

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -52,6 +52,13 @@ export def "install" []: nothing -> nothing {
     let v = (open pkgs/nu-git-manager/nupm.nuon).version
     let n = ^git describe | parse "{v}-{n}-{r}" | into record | get n? | default 0
     let version_cmd = [
+         "# see the version of NGM that is currently installed",
+         "#",
+         "# # Examples",
+         "# ```nushell",
+         "# # get the version of NGM",
+         "# gm version",
+         "# ```",
          "export def \"gm version\" []: nothing -> record<version: string, branch: string, commit: string, date: datetime> {",
          "    {",
         $"        version: \"($v)+($n)\",",


### PR DESCRIPTION
this new command is a bit special because it is only installed using `toolkit install` :open_mouth: 

the README and the bug report template have been updated accordingly.