### PR TITLE
Refactor command naming convention into actual modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ in your `config.nu` you can add the following to load `nu-git-manager` modules:
 use nu-git-manager *
 
 # the following are non-essential modules
-use nu-git-manager-sugar extra *              # augment `gm` with additional commands
+use nu-git-manager-sugar gm                   # augment `gm` with additional commands
+
+# or by category
+use nu-git-manager-sugar extra *
+use nu-git-manager-sugar git *
+use nu-git-manager-sugar github *
+use nu-git-manager-sugar dotfiles *
 ```
 
 > **Note**  

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/dotfiles.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/dotfiles.nu
@@ -2,6 +2,7 @@
 #
 # the goal of `gm cfg` is to provide tools to interact with dotfiles managed
 # through a _bare_ repo.
+export module gm { export module cfg {
 
 # manage dotfiles from anywhere
 #
@@ -25,7 +26,7 @@
 # # get the current status of the dotfiles in short format
 # gm status --short
 # ```
-export def --wrapped "gm cfg" [...args] {
+export def --wrapped "main" [...args] {
     ^git --git-dir $env.DOTFILES_GIT_DIR --work-tree $env.DOTFILES_WORKTREE ...$args
 }
 
@@ -39,7 +40,7 @@ def "ansi cmd" []: string -> string {
 # - let you fuzzy search amongst all the dotfiles
 # - switch to the parent directory of the selected dotfile
 # - open the selected dotfile in `$env.EDITOR`
-export def "gm cfg edit" [] {
+export def "edit" [] {
     let git_options = [
         --git-dir $env.DOTFILES_GIT_DIR
         --work-tree $env.DOTFILES_WORKTREE
@@ -58,3 +59,5 @@ export def "gm cfg edit" [] {
     cd ($config_file | path dirname)
     ^$env.EDITOR $config_file
 }
+
+} }

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/extra.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/extra.nu
@@ -1,6 +1,7 @@
 # extends the core `gm` command with additional subcommands.
 #
 # /!\ this module is part of the optional NGM. /!\
+export module gm {
 
 # get a full report about the local store of repositories
 #
@@ -24,7 +25,7 @@
 # │ 11 │ clean     │
 # ╰────┴───────────╯
 # ```
-export def "gm report" []: nothing -> table<name: string, branch: string, remote: string, tag: string, index: int, ignored: int, conflicts: int, ahead: int, behind: int, worktree: int, stashes: int, clean: bool> {
+export def "report" []: nothing -> table<name: string, branch: string, remote: string, tag: string, index: int, ignored: int, conflicts: int, ahead: int, behind: int, worktree: int, stashes: int, clean: bool> {
     if (which gstat | is-empty) {
         error make --unspanned {
             msg: (
@@ -73,4 +74,6 @@ export def "gm report" []: nothing -> table<name: string, branch: string, remote
                 + $in.stashes
             ) == 0
         }
+}
+
 }

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
@@ -12,6 +12,7 @@ use completions [
 ]
 
 export module prompt.nu
+export module gm { export module repo {
 
 # get the commit hash of any revision
 #
@@ -25,14 +26,14 @@ export module prompt.nu
 # # get the commit hash of the main branch
 # gm repo get commit main
 # ```
-export def "gm repo get commit" [
+export def "get commit" [
     revision: string = "HEAD"  # the revision to get the hash of
 ]: nothing -> string {
     (^git rev-parse $revision)
 }
 
 # compare the changes between two revisions, from a target to the "head"
-export def "gm repo compare" [
+export def "compare" [
     target: string, # the target to compare from
     --head: string = "HEAD", # the "head" to use for the comparison
 ]: nothing -> string {
@@ -53,13 +54,13 @@ def repo-root []: nothing -> string {
 # ```
 # /path/to/repo
 # ```
-export def --env "gm repo goto root" []: nothing -> nothing {
+export def --env "goto root" []: nothing -> nothing {
     cd (repo-root)
 }
 
 # inspect local branches
 #
-# > **Note**  
+# > **Note**
 # > in the following, a "*dangling*" branch refers to a branch that does not have any remote
 # > counterpart, i.e. it's a purely local branch.
 #
@@ -73,7 +74,7 @@ export def --env "gm repo goto root" []: nothing -> nothing {
 # # clean all dangling branches
 # gm repo branches --clean
 # ```
-export def "gm repo branches" [
+export def "branches" [
     --clean  # clean all dangling branches
 ]: nothing -> table<branch: string, remotes: list<string>> {
     let local_branches = ^git branch --list
@@ -114,7 +115,7 @@ export def "gm repo branches" [
 }
 
 # wipe a branch completely, i.e. both locally and remotely
-export def "gm repo branch wipe" [
+export def "branch wipe" [
     branch: string, # the branch to wipe
     remote: string, # the remote to push to
 ]: nothing -> nothing {
@@ -141,7 +142,7 @@ export def "gm repo branch wipe" [
 # ```
 # false
 # ```
-export def "gm repo is-ancestor" [
+export def "is-ancestor" [
     a: string  # the base commit-ish revision
     b: string  # the *head* commit-ish revision
 ]: nothing -> bool {
@@ -160,7 +161,7 @@ export def "gm repo is-ancestor" [
 # 0│origin│https://github.com/amtoine/nu-git-manager│ssh://github.com/amtoine/nu-git-manager
 # ─┴──────┴─────────────────────────────────────────┴───────────────────────────────────────
 # ```
-export def "gm repo remote list" []: nothing -> table<remote: string, fetch: string, push: string> {
+export def "remote list" []: nothing -> table<remote: string, fetch: string, push: string> {
     # FIXME: use the helper `list-remotes` command from ../nu-git-manager/git/repo.nu:29
     ^git remote --verbose
         | detect columns --no-headers
@@ -175,7 +176,7 @@ export def "gm repo remote list" []: nothing -> table<remote: string, fetch: str
 }
 
 # fetch a remote branch locally, without pulling down the whole remote
-export def "gm repo fetch branch" [
+export def "fetch branch" [
     remote: string@get-remotes, # the branch to fetch
     branch: string@get-branches, # the remote to fetch the branch from
     --strategy: string@get-strategies = "none" # the merge strategy to use
@@ -227,7 +228,7 @@ def get-branches [--merged, --no-merged]: nothing -> list<string> {
 }
 
 # remove a branch interactively
-export def "gm repo branch interactive-delete" []: nothing -> nothing {
+export def "branch interactive-delete" []: nothing -> nothing {
     let choice = get-branches | input list --multi "remove"
     if ($choice | is-empty) {
         return
@@ -247,7 +248,7 @@ export def "gm repo branch interactive-delete" []: nothing -> nothing {
 }
 
 # switch between branches interactively
-export def "gm repo switch" []: nothing -> nothing {
+export def "switch" []: nothing -> nothing {
     let res = ^git branch --all
         | lines
         | str replace --regex '^  (remotes/.*)' $'  (ansi default_dimmed)${1}(ansi reset)'
@@ -271,7 +272,7 @@ export def "gm repo switch" []: nothing -> nothing {
 }
 
 # get some information about a repo
-export def "gm repo ls" [
+export def "ls" [
     repo?: path, # the path to the repo (defaults to `.`)
 ]: nothing -> record<path: path, name: string, staged: list<string>, unstaged: list<string>, untracked: list<string>, last_commit: record<date: datetime, title: string, hash: string>, branch: string> {
     let repo = $repo | default (pwd)
@@ -321,7 +322,7 @@ export def "gm repo ls" [
 # 2│Mel Massadian │       654│       64
 # ─┴──────────────┴──────────┴─────────
 # ```
-export def "gm repo query" [table: string@git-query-tables]: nothing -> table {
+export def "query" [table: string@git-query-tables]: nothing -> table {
     if $table not-in $GIT_QUERY_TABLES {
         error make {
             msg: $"(ansi red_bold)invalid_qit_query_table(ansi reset)",
@@ -381,7 +382,7 @@ def throw-error [
 # # `--good` and `--bad` are indeed "good" and "bad"
 # gm repo bisect --good $good --bad $bad --no-check $test
 # ```
-export def "gm repo bisect" [
+export def "bisect" [
     test: closure, # the code to run to check a given revision, should return a non-zero exit code for bad revisions
     --good: string, # the initial known "good" revision
     --bad: string, # the initial known "bad" revision
@@ -474,3 +475,5 @@ export def "gm repo bisect" [
 
     $first_bad
 }
+
+} }

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
@@ -298,6 +298,8 @@ export def "ls" [
     }
 }
 
+alias '_query git' = query git
+
 # queries the `.git/` directory as a database with `nu_plugin_git_query`
 #
 # ## Examples
@@ -333,7 +335,7 @@ export def "query" [table: string@git-query-tables]: nothing -> table {
         }
     }
 
-    if (which "query git" | is-empty) {
+    if (which "_query git" | is-empty) {
         error make --unspanned {
             msg: (
                 $"(ansi red_bold)requirement_not_found(ansi reset):\n"
@@ -345,9 +347,9 @@ export def "query" [table: string@git-query-tables]: nothing -> table {
     }
 
     if $table == "commits" {
-        query git $"select * from commits" | into datetime datetime
+        _query git $"select * from commits" | into datetime datetime
     } else {
-        query git $"select * from ($table)"
+        _query git $"select * from ($table)"
     }
 }
 

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/github.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/github.nu
@@ -1,6 +1,7 @@
 # provides helper commands to simplify the use of the GitHub CLI.
 #
 # /!\ this module is part of the optional NGM. /!\
+export module gm { export module gh {
 
 use std log
 
@@ -63,7 +64,7 @@ def "warning make" [
 
 # query the GitHub API for any end point
 #
-# > :bulb: **Note**  
+# > :bulb: **Note**
 # > see the [rest API of GitHub](https://docs.github.com/en/rest) for a complete
 # > list of available end points and documentation
 #
@@ -84,7 +85,7 @@ def "warning make" [
 # ```
 # you shall not rebase in the middle of a PR review nor close other's review threads :pray:
 # ```
-export def "gm gh query-api" [
+export def "query-api" [
     end_point: string # the end point in the GitHub API to query
     --page-size: int = 100 # the size of each page
     --no-paginate # do not paginate the API, useful when getting a single record
@@ -189,7 +190,7 @@ export def "gm gh query-api" [
 #     | last
 #     | select tag_name published_at
 # ```
-export def "gm gh query-releases" [
+export def "query-releases" [
     repo: string # the GitHub repository to query the releases of
     --page-size: int = 100 # the size of each page
     --no-gh # force to use `http get` instead of `gh`
@@ -204,7 +205,7 @@ export def "gm gh query-releases" [
 # # get the avatar picture of @amtoine
 # gm gh query-user amtoine | get avatar_url | http get $in | save --force amtoine.png
 # ```
-export def "gm gh query-user" [
+export def "query-user" [
     user: string # the user to query information about
     --no-gh # force to use `http get` instead of `gh`
 ]: nothing -> record<login: string, id: int, node_id: string, avatar_url: string, gravatar_id: string, url: string, html_url: string, followers_url: string, following_url: string, gists_url: string, starred_url: string, subscriptions_url: string, organizations_url: string, repos_url: string, events_url: string, received_events_url: string, type: string, site_admin: bool, name: string, company: string, blog: string, location: string, email: nothing, hireable: nothing, bio: string, twitter_username: nothing, public_repos: int, public_gists: int, followers: int, following: int, created_at: string, updated_at: string> {
@@ -212,7 +213,7 @@ export def "gm gh query-user" [
 }
 
 # checkout one of the repo's PR interactively
-export def "gm gh pr checkout" []: nothing -> nothing {
+export def "pr checkout" []: nothing -> nothing {
     if (which gh --all | where type == external | is-empty) {
         error make --unspanned {
             msg: (
@@ -268,3 +269,5 @@ export def "gm gh pr checkout" []: nothing -> nothing {
         $res | ansi strip | parse "{author} ({number}): {title}" | into record | get number
     )
 }
+
+} }

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/github.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/github.nu
@@ -195,7 +195,7 @@ export def "query-releases" [
     --page-size: int = 100 # the size of each page
     --no-gh # force to use `http get` instead of `gh`
 ]: nothing -> table<url: string, assets_url: string, upload_url: string, html_url: string, id: int, author: record<login: string, id: int, node_id: string, avatar_url: string, gravatar_id: string, url: string, html_url: string, followers_url: string, following_url: string, gists_url: string, starred_url: string, subscriptions_url: string, organizations_url: string, repos_url: string, events_url: string, received_events_url: string, type: string, site_admin: bool>, node_id: string, tag_name: string, target_commitish: string, name: string, draft: bool, prerelease: bool, created_at: string, published_at: string, assets: list<any>, tarball_url: string, zipball_url: string, body: string, reactions: record<url: string, total_count: int, +1: int, -1: int, laugh: int, hooray: int, confused: int, heart: int, rocket: int, eyes: int>, mentions_count: int> {
-    gm gh query-api $"/repos/($repo)/releases" --page-size $page_size --no-gh=$no_gh
+    query-api $"/repos/($repo)/releases" --page-size $page_size --no-gh=$no_gh
 }
 
 # get information about a GitHub user
@@ -209,7 +209,7 @@ export def "query-user" [
     user: string # the user to query information about
     --no-gh # force to use `http get` instead of `gh`
 ]: nothing -> record<login: string, id: int, node_id: string, avatar_url: string, gravatar_id: string, url: string, html_url: string, followers_url: string, following_url: string, gists_url: string, starred_url: string, subscriptions_url: string, organizations_url: string, repos_url: string, events_url: string, received_events_url: string, type: string, site_admin: bool, name: string, company: string, blog: string, location: string, email: nothing, hireable: nothing, bio: string, twitter_username: nothing, public_repos: int, public_gists: int, followers: int, following: int, created_at: string, updated_at: string> {
-    gm gh query-api $"/users/($user)" --no-paginate --no-gh=$no_gh
+    query-api $"/users/($user)" --no-paginate --no-gh=$no_gh
 }
 
 # checkout one of the repo's PR interactively
@@ -231,7 +231,7 @@ export def "pr checkout" []: nothing -> nothing {
     }
 
     log debug $"pulling down list of pull requests for '($repo)'"
-    let prs = gm gh query-api $"/repos/($repo)/pulls"
+    let prs = query-api $"/repos/($repo)/pulls"
         | select number user.login title
         | rename id author title
     if ($prs | is-empty) {

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
@@ -10,7 +10,7 @@ export module extra.nu
 export module git/
 export module github.nu
 export module dotfiles.nu
-# workarounds for multiple bugs with export use
+# workarounds below explained in #184
 export module gm {
   use extra.nu gm; export use gm *
   use git/ gm repo; export module repo { export use repo * }

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
@@ -12,8 +12,14 @@ export module github.nu
 export module dotfiles.nu
 # workarounds below explained in #184
 export module gm {
-  use extra.nu gm; export use gm *
-  use git/ gm repo; export module repo { export use repo * }
-  use github.nu gm gh; export module gh { export use gh * }
-  use dotfiles.nu gm cfg; export module cfg { export use cfg * }
+    use extra.nu gm; export use gm *
+    export module repo {
+        use git/ gm repo; export use repo *
+    }
+    export module gh {
+        use github.nu gm gh; export use gh *
+    }
+    export module cfg {
+        use dotfiles.nu gm cfg; export use cfg *
+    }
 }

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
@@ -10,3 +10,10 @@ export module extra.nu
 export module git/
 export module github.nu
 export module dotfiles.nu
+# workarounds for multiple bugs with export use
+export module gm {
+  use extra.nu gm; export use gm *
+  use git/ gm repo; export module repo { export use repo * }
+  use github.nu gm gh; export module gh { export use gh * }
+  use dotfiles.nu gm cfg; export module cfg { export use cfg * }
+}

--- a/pkgs/nu-git-manager-sugar/tests/git.nu
+++ b/pkgs/nu-git-manager-sugar/tests/git.nu
@@ -1,16 +1,6 @@
 use std assert
 
-use ../../../pkgs/nu-git-manager-sugar/nu-git-manager-sugar/ git [
-    "gm repo get commit"
-    "gm repo goto root"
-    "gm repo branches"
-    "gm repo is-ancestor"
-    "gm repo remote list"
-    "gm repo fetch branch"
-    "gm repo ls"
-    "gm repo branch wipe"
-    "gm repo compare"
-]
+use ../../../pkgs/nu-git-manager-sugar/nu-git-manager-sugar/ git gm
 use ../../../pkgs/nu-git-manager/nu-git-manager/fs path ["path sanitize"]
 use ../../../tests/common/setup.nu [get-random-test-dir]
 

--- a/pkgs/nu-git-manager-sugar/tests/mod.nu
+++ b/pkgs/nu-git-manager-sugar/tests/mod.nu
@@ -9,11 +9,11 @@ const MODULE = "nu-git-manager-sugar"
 
 export module imports {
     export def extra [] {
-        assert imports $MODULE "extra" [ "gm report" ]
+        assert imports $MODULE "extra *" [ "gm report" ]
     }
 
     export def git [] {
-        assert imports $MODULE "git" [
+        assert imports $MODULE "git *" [
             "gm repo bisect",
             "gm repo branch interactive-delete",
             "gm repo branch wipe",
@@ -32,11 +32,63 @@ export module imports {
     }
 
     export def github [] {
-        assert imports $MODULE "github" [
+        assert imports $MODULE "github *" [
             "gm gh pr checkout",
             "gm gh query-api",
             "gm gh query-releases",
             "gm gh query-user",
+        ]
+    }
+
+    export def gm [] {
+        assert imports $MODULE "gm" [
+            "gm cfg",
+            "gm cfg edit",
+            "gm gh pr checkout",
+            "gm gh query-api",
+            "gm gh query-releases",
+            "gm gh query-user",
+            "gm repo bisect",
+            "gm repo branch interactive-delete",
+            "gm repo branch wipe",
+            "gm repo branches",
+            "gm repo compare",
+            "gm repo fetch branch",
+            "gm repo get commit",
+            "gm repo goto root",
+            "gm repo is-ancestor",
+            "gm repo ls",
+            "gm repo query",
+            "gm repo remote list",
+            "gm repo switch",
+            "gm report",
+        ]
+    }
+
+    export def repo [] {
+        assert imports $MODULE "gm repo" [
+            "repo bisect",
+            "repo branch interactive-delete",
+            "repo branch wipe",
+            "repo branches",
+            "repo compare",
+            "repo fetch branch",
+            "repo get commit",
+            "repo goto root",
+            "repo is-ancestor",
+            "repo ls",
+            "repo query",
+            "repo remote list",
+            "repo switch",
+        ]
+    }
+
+    export def gh [] {
+        assert imports $MODULE "gm gh" [
+            "gh pr checkout",
+            "gh query-api",
+            "gh query-releases",
+            "gh query-user",
         ]
     }
 }

--- a/pkgs/nu-git-manager-sugar/tests/mod.nu
+++ b/pkgs/nu-git-manager-sugar/tests/mod.nu
@@ -42,7 +42,7 @@ export module imports {
 
     export def gm [] {
         assert imports $MODULE "gm" [
-            "gm cfg",
+            "gm cfg cfg",
             "gm cfg edit",
             "gm gh pr checkout",
             "gm gh query-api",

--- a/pkgs/nu-git-manager-sugar/tests/mod.nu
+++ b/pkgs/nu-git-manager-sugar/tests/mod.nu
@@ -42,7 +42,7 @@ export module imports {
 
     export def gm [] {
         assert imports $MODULE "gm" [
-            "gm cfg cfg",
+            "gm cfg cfg", # FIXME: caused by workarounds in main mod.nu
             "gm cfg edit",
             "gm gh pr checkout",
             "gm gh query-api",

--- a/pkgs/nu-git-manager/nu-git-manager/mod.nu
+++ b/pkgs/nu-git-manager/nu-git-manager/mod.nu
@@ -12,6 +12,7 @@ module completions.nu
 module error.nu
 module fs/
 module git/
+export module gm {
 
 use fs store [get-repo-store-path, list-repos-in-store]
 use fs cache [
@@ -60,7 +61,7 @@ use completions
 # ```
 # ~/foo/nu-git-manager/cache.nuon
 # ```
-export def "gm" []: nothing -> nothing {
+export def "main" []: nothing -> nothing {
     print (help gm)
 }
 
@@ -93,7 +94,7 @@ export def "gm" []: nothing -> nothing {
 # # clone a big repo as a single commit, avoiding all intermediate Git deltas
 # gm clone https://github.com/neovim/neovim --depth 1
 # ```
-export def "gm clone" [
+export def "clone" [
     url: string # the URL to the repository to clone, supports HTTPS and SSH links, as well as references ending in `.git` or starting with `git@`
     --remote: string = "origin" # the name of the remote to setup
     --ssh # setup the remote to use the SSH protocol both to FETCH and to PUSH
@@ -221,7 +222,7 @@ export def "gm clone" [
 # # jump to a directory in the store
 # cd (gm list --full-path | input list)
 # ```
-export def "gm list" [
+export def "list" [
     --full-path # show the full path instead of only the "owner + group + repo" name
 ]: nothing -> list<path> {
     let cache_file = get-repo-store-cache-path
@@ -289,7 +290,7 @@ export def "gm list" [
 # # update the cache if necessary
 # if (gm status).should_update_cache { gm update-cache }
 # ```
-export def "gm status" []: nothing -> record<root: record<path: path, exists: bool>, missing: list<path>, cache: record<path: path, exists: bool>, should_update_cache: bool> {
+export def "status" []: nothing -> record<root: record<path: path, exists: bool>, missing: list<path>, cache: record<path: path, exists: bool>, should_update_cache: bool> {
     let root = get-repo-store-path
     let cache = get-repo-store-cache-path
 
@@ -322,7 +323,7 @@ export def "gm status" []: nothing -> record<root: record<path: path, exists: bo
 # # update the cache of repositories
 # gm update-cache
 # ```
-export def "gm update-cache" []: nothing -> nothing {
+export def "update-cache" []: nothing -> nothing {
     let cache_file = get-repo-store-cache-path
     clean-cache-dir $cache_file
 
@@ -359,7 +360,7 @@ export def "gm update-cache" []: nothing -> nothing {
 # # remove a precise repo without confirmation
 # gm remove amtoine/nu-git-manager --no-confirm
 # ```
-export def "gm remove" [
+export def "remove" [
     pattern?: string # a pattern to restrict the choices
     --fuzzy # remove after fuzzy-finding the repo(s) to clean
     --no-confirm # do not ask for confirmation: useful in scripts but requires a single match
@@ -487,7 +488,7 @@ export def "gm remove" [
 #     8f3b273337b53bd86d5594d5edc9d4ad7242bd4c: "github.com/amtoine/nushell",
 # }
 # ```
-export def "gm squash-forks" [
+export def "squash-forks" [
     --non-interactive-preselect: record = {} # the non-interactive preselection record, see documentation above
 ]: nothing -> nothing {
     let status = gm status
@@ -564,7 +565,7 @@ export def "gm squash-forks" [
 # # list the leaves of the store that would have to be cleaned
 # gm clean --list
 # ```
-export def "gm clean" [
+export def "clean" [
     --list # only list without cleaning
 ]: nothing -> list<path> {
     let empty_directories_in_store = ls (gm status | get root.path | path join "**")
@@ -582,4 +583,6 @@ export def "gm clean" [
     }
 
     $empty_non_repo_directories_in_store | clean-empty-directories-rec
+}
+
 }

--- a/pkgs/nu-git-manager/nu-git-manager/mod.nu
+++ b/pkgs/nu-git-manager/nu-git-manager/mod.nu
@@ -366,7 +366,7 @@ export def "remove" [
     --no-confirm # do not ask for confirmation: useful in scripts but requires a single match
 ]: nothing -> nothing {
     let root = get-repo-store-path
-    let choices = gm list | path remove-prefix $root | find $pattern
+    let choices = list | path remove-prefix $root | find $pattern
 
     let repo_to_remove = match ($choices | length) {
         0 => {
@@ -491,7 +491,7 @@ export def "remove" [
 export def "squash-forks" [
     --non-interactive-preselect: record = {} # the non-interactive preselection record, see documentation above
 ]: nothing -> nothing {
-    let status = gm status
+    let status = status
 
     let forks_to_squash = open $status.cache.path --raw
         | from nuon
@@ -541,7 +541,7 @@ export def "squash-forks" [
                 ^git -C $main remote set-url --push ($fork_name) $fork_origin.push
 
                 log debug $"    removing ($fork_full_name)"
-                gm remove --no-confirm $fork_full_name
+                remove --no-confirm $fork_full_name
             }
         }
     }
@@ -568,12 +568,12 @@ export def "squash-forks" [
 export def "clean" [
     --list # only list without cleaning
 ]: nothing -> list<path> {
-    let empty_directories_in_store = ls (gm status | get root.path | path join "**")
+    let empty_directories_in_store = ls (status | get root.path | path join "**")
         | where (ls $it.name | is-empty)
         | get name
         | path expand
         | each { path sanitize }
-    let cached_repos = gm list --full-path
+    let cached_repos = list --full-path
 
     let empty_non_repo_directories_in_store = $empty_directories_in_store
         | where not ($cached_repos | any {|repo| $it | str starts-with $repo})

--- a/pkgs/nu-git-manager/tests/gm.nu
+++ b/pkgs/nu-git-manager/tests/gm.nu
@@ -336,7 +336,7 @@ export def store-cleaning [] {
 }
 
 export def user-import [] {
-    assert imports "nu-git-manager" "" [
+    let imports = [
         "gm",
         "gm clean",
         "gm clone",
@@ -346,4 +346,6 @@ export def user-import [] {
         "gm status",
         "gm update-cache",
     ]
+    assert imports "nu-git-manager" "*" $imports
+    assert imports "nu-git-manager" "gm" $imports
 }

--- a/tests/common/import.nu
+++ b/tests/common/import.nu
@@ -6,7 +6,7 @@ export def "assert imports" [
     | to nuon
     " | from nuon
     let after = ^$nu.current-exe --no-config-file --commands $"
-        use ./($module)/ ($submodule) *
+        use ./($module)/ ($submodule)
         scope commands | get name
     | to nuon" | from nuon
 

--- a/tests/common/import.nu
+++ b/tests/common/import.nu
@@ -3,8 +3,7 @@ export def "assert imports" [
 ] {
     let before = ^$nu.current-exe --no-config-file --commands "
         scope commands | get name
-    | to nuon
-    " | from nuon
+    | to nuon" | from nuon
     let after = ^$nu.current-exe --no-config-file --commands $"
         use ./($module)/ ($submodule)
         scope commands | get name


### PR DESCRIPTION
This PR enables the following:

```nu
use nu-git-manager-sugar gm # all gm commands
use gm gh # shortcut for gh commands
```

- [x] Add tests
- [x] Add modules
- [x] Add global `gm` export
- [x] Pass tests
- [x] Update readme

Mostly mechanical changes. Module contents were left unindented to improve diff readability. 1 innocuous change took me hours and needs documented for future maintenance:

```diff
--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/mod.nu
 export module git/
 export module github.nu
 export module dotfiles.nu
+# workarounds below explained in #184
+export module gm {
+    use extra.nu gm; export use gm *
+    export module repo {
+        use git/ gm repo; export use repo *
+    }
+    export module gh {
+        use github.nu gm gh; export use gh *
+    }
+    export module cfg {
+        use dotfiles.nu gm cfg; export use cfg *
+    }
}
```

> [!WARNING]
> ### Here be dragons 🐲

My first attempt was to `export use` each module:

```nushell
export use extra.nu
export use extra gm
export use git/
export use git gm
# etc
```

But `export use` partially hides nested modules (nushell/nushell#12066) so:

```nushell
export module extra.nu # revert to export module
export use extra.nu gm # export use file path
export module git/
export use git/ gm
# etc
```

But `export use` shadows modules instead of merging them (TODO: report bug) so:

```nushell
export module extra.nu
export module git/
# etc
export module gm { # wrapping module
    export use extra.nu gm * # all child members
    export use git/ gm *
    # etc
}
```

But `export use` doesn't permit multiple module chain members (nushell/nushell#12057) so:

```nushell
export module extra.nu
export module git/
# etc
export module gm {
    use extra.nu gm; export use gm * # use before export use
    use git/ gm; export use gm *
    # etc
}
```

But `export use` still hides submodules so:

```nushell
export module extra.nu
export module git/
# etc
export module gm {
    use extra.nu gm; export use gm *
    export module repo { # another wrapping module
        use git/ gm repo; export use repo * # all grandchildren
    }
    # etc
}
```

None of these workarounds would be necessary using 1 file per submodule because they could be passed to `export module` above instead of `export use`. A less brittle alternative would be to create a directory for each category module, 1 script for each leaf module, and 1 `mod.nu` to wrap it in the `gm` namespace. For example:

```
📂 github
  📄 gh.nu
    🥡 everthing in github.nu now
  📄 mod.nu
    📦 export module gm { export module gh.nu }
    🥡 anything outside gh goes here
```