### PR TITLE
fix globbing

### DIFF
--- a/pkgs/nu-git-manager/nu-git-manager/mod.nu
+++ b/pkgs/nu-git-manager/nu-git-manager/mod.nu
@@ -567,7 +567,7 @@ export def "gm squash-forks" [
 export def "gm clean" [
     --list # only list without cleaning
 ]: nothing -> list<path> {
-    let empty_directories_in_store = ls (gm status | get root.path | path join "**")
+    let empty_directories_in_store = ls (gm status | get root.path | path join "**" | into glob)
         | where (ls $it.name | is-empty)
         | get name
         | path expand

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -194,7 +194,7 @@ def run-nu [code: string]: nothing -> any {
 }
 
 def rg [root: path, pattern: string]: nothing -> table<file: path, line: int, match: string> {
-    ls ($root | path join "**" "*")
+    ls ($root | path join "**" "*" | into glob)
         | where type == file
         | get name
         | wrap file


### PR DESCRIPTION
this comes with the new release of Nushell: [0.91.0](https://www.nushell.sh/blog/2024-03-05-nushell_0_91_0.html#handling-globs-for-variables).

this PR changes all occurences of `**` in a path given to `ls`.

> **Note**
> `glob` does not need to be updated as per the release note