### PR TITLE
bump Nushell and Nupm in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
   tests:
     uses: ./.github/workflows/nupm-tests.yml
     with:
-      nu_version: "0.90.1"
-      nupm_revision: "66e2eaa848e3f72c1b4a841f26f4dc7efc4fedb9"
+      nu_version: "0.91.0"
+      nupm_revision: "29916fc43aad40ffe901b3c0be8820b9cb78fdba"
 
   documentation:
     uses: ./.github/workflows/check-documentation.yml
     with:
-      nu_version: "0.90.1"
+      nu_version: "0.91.0"

--- a/pkgs/nu-git-manager-sugar/tests/git.nu
+++ b/pkgs/nu-git-manager-sugar/tests/git.nu
@@ -125,7 +125,7 @@ export def remote-list [] {
 }
 
 def "assert simple-git-tree-equal" [expected: list<string>, --extra-revs: list<string> = []] {
-    let actual = ^git log --oneline --decorate --graph --all $extra_revs
+    let actual = ^git log --oneline --decorate --graph --all ...$extra_revs
         | lines
         | parse "* {hash} {tree}"
         | get tree

--- a/pkgs/nu-git-manager/nu-git-manager/mod.nu
+++ b/pkgs/nu-git-manager/nu-git-manager/mod.nu
@@ -567,7 +567,7 @@ export def "gm squash-forks" [
 export def "gm clean" [
     --list # only list without cleaning
 ]: nothing -> list<path> {
-    let empty_directories_in_store = ls (gm status | get root.path | path join "**")
+    let empty_directories_in_store = ls (gm status | get root.path | path join "**" | into glob)
         | where (ls $it.name | is-empty)
         | get name
         | path expand

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -194,7 +194,7 @@ def run-nu [code: string]: nothing -> any {
 }
 
 def rg [root: path, pattern: string]: nothing -> table<file: path, line: int, match: string> {
-    ls ($root | path join "**" "*")
+    ls ($root | path join "**" "*" | into glob)
         | where type == file
         | get name
         | wrap file


### PR DESCRIPTION
as per title

from https://github.com/amtoine/nu-git-manager/pull/187
> this comes with the new release of Nushell: [0.91.0](https://www.nushell.sh/blog/2024-03-05-nushell_0_91_0.html#handling-globs-for-variables).
> 
> this PR changes all occurences of `**` in a path given to `ls`.
> 
> > **Note**
> > `glob` does not need to be updated as per the release note
