### PR TITLE
make sure Git does not give an error in the prompt

### DIFF
--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/lib/prompt.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/lib/prompt.nu
@@ -4,7 +4,10 @@ use style.nu [color, simplify-path]
 # /!\ the PWD will be sanitized
 export def get-left-prompt [duration_threshold: duration]: nothing -> string {
     let is_git_repo = not (
-        do --ignore-errors { ^git rev-parse --is-inside-work-tree } | is-empty
+        do --ignore-errors { ^git rev-parse --is-inside-work-tree }
+            | complete
+            | get stdout
+            | is-empty
     )
 
     # FIXME: use `path sanitize` from `nu-git-manager`


### PR DESCRIPTION
when not in a Git repo and using Nushell 0.92.0, this previous `do` block would print "not in a Git repo" on each prompt update...