### PR TITLE
use a default "fetch" strategy

### DIFF
--- a/docs/nu-git-manager-sugar/git/gm-repo-bisect.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-bisect.md
@@ -1,4 +1,4 @@
-# `gm repo bisect` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L435))
+# `gm repo bisect` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L440))
 bisect a worktree by running a piece of code repeatedly
 
 # Examples

--- a/docs/nu-git-manager-sugar/git/gm-repo-branch-fetch.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-branch-fetch.md
@@ -6,7 +6,8 @@ fetch a remote branch locally, without pulling down the whole remote
 ## Parameters
 - `remote` <`string@get-remotes`>: the branch to fetch
 - `branch` <`string@get-branches`>: the remote to fetch the branch from
-- `--strategy` <`string@get-strategies`> = `none`: the merge strategy to use
+- `--strategy` <`string@get-strategies`>: the merge strategy to use, defaults to the `pull.rebase` Git
+config option
 
 
 ## Signatures

--- a/docs/nu-git-manager-sugar/git/gm-repo-branch-interactive-delete.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-branch-interactive-delete.md
@@ -1,4 +1,4 @@
-# `gm repo branch interactive-delete` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L281))
+# `gm repo branch interactive-delete` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L286))
 remove a branch interactively
 
 

--- a/docs/nu-git-manager-sugar/git/gm-repo-ls.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-ls.md
@@ -1,4 +1,4 @@
-# `gm repo ls` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L325))
+# `gm repo ls` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L330))
 get some information about a repo
 
 

--- a/docs/nu-git-manager-sugar/git/gm-repo-query.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-query.md
@@ -1,4 +1,4 @@
-# `gm repo query` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L375))
+# `gm repo query` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L380))
 queries the `.git/` directory as a database with `nu_plugin_git_query`
 
 ## Examples

--- a/docs/nu-git-manager-sugar/git/gm-repo-switch.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-switch.md
@@ -1,4 +1,4 @@
-# `gm repo switch` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L301))
+# `gm repo switch` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L306))
 switch between branches interactively
 
 

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu
@@ -229,8 +229,13 @@ export def "gm repo remote add" [name: string, remote: string, --ssh]: nothing -
 export def "gm repo branch fetch" [
     remote: string@get-remotes, # the branch to fetch
     branch: string@get-branches, # the remote to fetch the branch from
-    --strategy: string@get-strategies = "none" # the merge strategy to use
+    --strategy: string@get-strategies # the merge strategy to use, defaults to the `pull.rebase` Git
+                                      # config option
 ]: nothing -> nothing {
+    let strategy = $strategy | default (
+        if (^git config pull.rebase) == "true" { "rebase" } else { "merge" }
+    )
+
     ^git fetch $remote $branch
 
     if (^git branch --list | lines | str substring 2.. | where $it == $branch | is-empty) {

--- a/pkgs/nu-git-manager-sugar/tests/git.nu
+++ b/pkgs/nu-git-manager-sugar/tests/git.nu
@@ -146,7 +146,7 @@ export def branch-fetch [] {
 
     do {
         cd $bar
-        gm repo branch fetch $"file://($foo)" foo
+        gm repo branch fetch $"file://($foo)" foo --strategy none
 
         assert simple-git-tree-equal [
             "(foo) c2",
@@ -159,7 +159,7 @@ export def branch-fetch [] {
 
     do {
         cd $bar
-        gm repo branch fetch $"file://($foo)" foo
+        gm repo branch fetch $"file://($foo)" foo --strategy none
 
         assert simple-git-tree-equal [
             "(foo) c4",
@@ -176,7 +176,7 @@ export def branch-fetch [] {
 
     do {
         cd $bar
-        gm repo branch fetch $"file://($foo)" foo
+        gm repo branch fetch $"file://($foo)" foo --strategy none
 
         assert simple-git-tree-equal --extra-revs ["FETCH_HEAD"] [
             "c6",


### PR DESCRIPTION
up until now, the default `strategy` for `gm repo branch fetch` has been `none`, which implies that, to have a proper "fetch strategy", `--strategy <strat>` had to be used every time...

however, in my Git config, i have `pull.rebase` set to `true`, which means i want to _rebase_ most of the time.

this PR makes it so that the default value of `strategy: string` is either `rebase` when `pull.rebase` is set or `merge` when it's not.

the "strategy" can always be
- overwritten with `--strategy rebase` or `--strategy merge`
- disabled with `--strategy none`