### PR TITLE
fix: collect the output of `gm repo compare` in the tests

### DIFF
--- a/pkgs/nu-git-manager-sugar/tests/git.nu
+++ b/pkgs/nu-git-manager-sugar/tests/git.nu
@@ -353,18 +353,17 @@ export def branch-compare [] {
         "+++ b/foo.txt",
         "@@ -0,0 +1 @@",
         "+foo",
-        "\\ No newline at end of file"
-        "",
+        "\\ No newline at end of file",
     ]
-    assert equal (gm repo compare main) ($expected | str join "\n")
-    assert equal (gm repo compare main --head HEAD) ($expected | str join "\n")
+    assert equal (gm repo compare main | collect) ($expected | str join "\n")
+    assert equal (gm repo compare main --head HEAD | collect) ($expected | str join "\n")
 
     ^git checkout main
     "bar" | save --append foo.txt
     ^git add foo.txt
     commit "c2"
 
-    assert equal (gm repo compare main --head foo) ($expected | str join "\n")
+    assert equal (gm repo compare main --head foo | collect) ($expected | str join "\n")
 
     clean $foo
 }


### PR DESCRIPTION
related to
- https://github.com/amtoine/nu-git-manager/actions/runs/10005343512/job/27655861805#step:6:329

running `tk test compare --verbose` would give the following error:
```
Error:   × invalid error format.
    ╭─[NU_STDLIB_VIRTUAL_DIR/std/assert.nu:44:16]
 43 │             msg: ($message | default "Assertion failed."),
 44 │ ╭─▶         label: ($error_label | default {
 45 │ │               text: "It is not true.",
 46 │ │               span: (metadata $condition).span,
 47 │ ├─▶         })
    · ╰──── `$.label.start` should be smaller than `$.label.end`
 48 │         }
    ╰────
  help: 112592 > 104293
```

it appears the `gm repo branch compare` command outputs a "byte stream" instead of a `string` :thinking: 
what i don't understand:
- where this error comes from
- why the `get-commit` test passes without `collect`, because `gm repo get commit` also returns a _byte stream_ instead of a `string`