### PR TITLE
bump to 0.9.0 and Nushell 0.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
   tests:
     uses: ./.github/workflows/nupm-tests.yml
     with:
-      nu_version: "0.91.0"
-      nupm_revision: "29916fc43aad40ffe901b3c0be8820b9cb78fdba"
+      nu_version: "0.96.0"
+      nupm_revision: "42d65a980641a9374473907d521f008e859c9ac7"
 
   documentation:
     uses: ./.github/workflows/check-documentation.yml
     with:
-      nu_version: "0.91.0"
+      nu_version: "0.96.0"

--- a/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/github.nu
+++ b/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/github.nu
@@ -143,7 +143,7 @@ export def "gm gh query-api" [
         if $no_paginate {
             http get ($base_url | update params.page 1 | url join)
         } else {
-            let res = generate 1 {|page|
+            let res = generate { |page|
                 log debug $"pulling page ($page)"
                 let resp = http get ($base_url | update params.page $page | url join)
 
@@ -173,7 +173,7 @@ export def "gm gh query-api" [
                         error make --unspanned { msg: $err_msg }
                     }
                 }
-            }
+            } 1
 
             $res | flatten
         }

--- a/pkgs/nu-git-manager-sugar/nupm.nuon
+++ b/pkgs/nu-git-manager-sugar/nupm.nuon
@@ -1,6 +1,6 @@
 {
     name: "nu-git-manager-sugar"
-    version: 0.8.0
+    version: 0.9.0
     description: "A collection of extra Nushell tools to manage `git` repositories."
     documentation: "https://github.com/amtoine/nu-git-manager/blob/main/README.md"
     maintainers: [
@@ -9,7 +9,7 @@
     ]
     license: "https://github.com/amtoine/nu-git-manager/blob/main/LICENSE"
     dependencies: {
-        nushell: 0.92.0
+        nushell: 0.96.0
         git: 2.40.1
         optionals: {
             "sugar gh": {

--- a/pkgs/nu-git-manager/nu-git-manager/fs/dir.nu
+++ b/pkgs/nu-git-manager/nu-git-manager/fs/dir.nu
@@ -4,7 +4,7 @@ use path.nu ["path sanitize"]
 #
 # /!\ this command will return sanitized paths /!\
 export def clean-empty-directories-rec []: list<path> -> list<path> {
-    let deleted = generate $in {|directories|
+    let deleted = generate {|directories|
         let next = $directories | each {|it|
             rm --force $it
 
@@ -19,7 +19,7 @@ export def clean-empty-directories-rec []: list<path> -> list<path> {
         } else {
             {out: $directories, next: $next}
         }
-    }
+    } $in
 
     $deleted | flatten
 }

--- a/pkgs/nu-git-manager/nupm.nuon
+++ b/pkgs/nu-git-manager/nupm.nuon
@@ -1,6 +1,6 @@
 {
     name: "nu-git-manager"
-    version: 0.8.0
+    version: 0.9.0
     description: "A collection of Nushell tools to manage `git` repositories."
     documentation: "https://github.com/amtoine/nu-git-manager/blob/main/README.md"
     maintainers: [
@@ -9,7 +9,7 @@
     ]
     license: "https://github.com/amtoine/nu-git-manager/blob/main/LICENSE"
     dependencies: {
-        nushell: 0.92.0
+        nushell: 0.96.0
         git: 2.40.1
     }
     type: "module"


### PR DESCRIPTION
this also fixes the order of arguments for `generate`.