### PR TITLE
show the deleted branches with `gm repo branch clean`

### DIFF
--- a/docs/nu-git-manager-sugar/git/gm-repo-bisect.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-bisect.md
@@ -1,4 +1,4 @@
-# `gm repo bisect` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L440))
+# `gm repo bisect` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L446))
 bisect a worktree by running a piece of code repeatedly
 
 # Examples

--- a/docs/nu-git-manager-sugar/git/gm-repo-branch-clean.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-branch-clean.md
@@ -15,6 +15,6 @@ gm repo branch clean
 
 
 ## Signatures
-| input     | output    |
-| --------- | --------- |
-| `nothing` | `nothing` |
+| input     | output                                  |
+| --------- | --------------------------------------- |
+| `nothing` | `table<name: string, revision: string>` |

--- a/docs/nu-git-manager-sugar/git/gm-repo-branch-fetch.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-branch-fetch.md
@@ -1,4 +1,4 @@
-# `gm repo branch fetch` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L229))
+# `gm repo branch fetch` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L235))
 fetch a remote branch locally, without pulling down the whole remote
 
 

--- a/docs/nu-git-manager-sugar/git/gm-repo-branch-interactive-delete.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-branch-interactive-delete.md
@@ -1,4 +1,4 @@
-# `gm repo branch interactive-delete` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L286))
+# `gm repo branch interactive-delete` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L292))
 remove a branch interactively
 
 

--- a/docs/nu-git-manager-sugar/git/gm-repo-branch-wipe.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-branch-wipe.md
@@ -1,4 +1,4 @@
-# `gm repo branch wipe` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L125))
+# `gm repo branch wipe` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L131))
 wipe a branch completely, i.e. both locally and remotely
 
 

--- a/docs/nu-git-manager-sugar/git/gm-repo-is-ancestor.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-is-ancestor.md
@@ -1,4 +1,4 @@
-# `gm repo is-ancestor` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L152))
+# `gm repo is-ancestor` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L158))
 return true iif the first revision is an ancestor of the second
 
 ## Examples

--- a/docs/nu-git-manager-sugar/git/gm-repo-ls.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-ls.md
@@ -1,4 +1,4 @@
-# `gm repo ls` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L330))
+# `gm repo ls` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L336))
 get some information about a repo
 
 

--- a/docs/nu-git-manager-sugar/git/gm-repo-query.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-query.md
@@ -1,4 +1,4 @@
-# `gm repo query` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L380))
+# `gm repo query` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L386))
 queries the `.git/` directory as a database with `nu_plugin_git_query`
 
 ## Examples

--- a/docs/nu-git-manager-sugar/git/gm-repo-remote-add.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-remote-add.md
@@ -1,4 +1,4 @@
-# `gm repo remote add` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L202))
+# `gm repo remote add` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L208))
 add a remote to the current repository
 
 > **Note**  

--- a/docs/nu-git-manager-sugar/git/gm-repo-remote-list.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-remote-list.md
@@ -1,4 +1,4 @@
-# `gm repo remote list` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L173))
+# `gm repo remote list` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L179))
 get the list of all the remotes in the current repository
 
 ## Examples

--- a/docs/nu-git-manager-sugar/git/gm-repo-remote.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-remote.md
@@ -1,4 +1,4 @@
-# `gm repo remote` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L159))
+# `gm repo remote` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L165))
 
 
 

--- a/docs/nu-git-manager-sugar/git/gm-repo-switch.md
+++ b/docs/nu-git-manager-sugar/git/gm-repo-switch.md
@@ -1,4 +1,4 @@
-# `gm repo switch` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L306))
+# `gm repo switch` from `nu-git-manager-sugar git` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager-sugar/nu-git-manager-sugar/git/mod.nu#L312))
 switch between branches interactively
 
 


### PR DESCRIPTION
`gm repo branch clean` will now return a `table<name: string, revision: string>` so that deleted branches can be easily resurrected.