### PR TITLE
fix `doc` in `toolkit.nu`

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -240,9 +240,9 @@ def document-command [
 
     let page = [
         $"# `($command)` from `($args.module_name)` \(see [source]\(($source)\)\)",
-        $help.usage,
+        $help.description,
         "",
-        $help.extra_usage,
+        $help.extra_description,
         "",
         "## Parameters",
         (
@@ -349,9 +349,9 @@ def document-module [
         let page = [
             $"# Module `($module_name)`",
             "## Description",
-            $module.usage,
+            $module.description,
             "",
-            $module.extra_usage,
+            $module.extra_description,
             "",
             "## Commands",
             $commands,


### PR DESCRIPTION
`$.usage` and `$.extra_usage` are now `$.description` and `$.extra_description` in the "help" pages of commands.