### PR TITLE
fix `gm clone` of empty repo

### DIFF
--- a/docs/nu-git-manager/gm-clean.md
+++ b/docs/nu-git-manager/gm-clean.md
@@ -1,4 +1,4 @@
-# `gm clean` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L567))
+# `gm clean` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L573))
 clean the store
 
 this command will mainly remove empty directory recursively.

--- a/docs/nu-git-manager/gm-list.md
+++ b/docs/nu-git-manager/gm-list.md
@@ -1,4 +1,4 @@
-# `gm list` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L224))
+# `gm list` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L230))
 list all the local repositories in your local store
 
 **/!\\** this command will return sanitized paths. **/!\\**

--- a/docs/nu-git-manager/gm-remove.md
+++ b/docs/nu-git-manager/gm-remove.md
@@ -1,4 +1,4 @@
-# `gm remove` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L362))
+# `gm remove` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L368))
 remove one of the repositories from your local store
 
 ## Examples

--- a/docs/nu-git-manager/gm-squash-forks.md
+++ b/docs/nu-git-manager/gm-squash-forks.md
@@ -1,4 +1,4 @@
-# `gm squash-forks` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L490))
+# `gm squash-forks` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L496))
 squash multi-directory forks into a single repo
 
 Here, two forks are defined as *two non-grafted repositories that share the same initial commit,

--- a/docs/nu-git-manager/gm-status.md
+++ b/docs/nu-git-manager/gm-status.md
@@ -1,4 +1,4 @@
-# `gm status` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L292))
+# `gm status` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L298))
 get current status about the repositories managed by NGM
 
 **/!\\** `$.root.path` and `$.cache.path` will be sanitized **/!\\**

--- a/docs/nu-git-manager/gm-update-cache.md
+++ b/docs/nu-git-manager/gm-update-cache.md
@@ -1,4 +1,4 @@
-# `gm update-cache` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L325))
+# `gm update-cache` from `nu-git-manager` (see [source](https://github.com/amtoine/nu-git-manager/blob/main/pkgs/nu-git-manager/nu-git-manager/mod.nu#L331))
 update the local cache of repositories
 
 ## Examples

--- a/pkgs/nu-git-manager/nu-git-manager/mod.nu
+++ b/pkgs/nu-git-manager/nu-git-manager/mod.nu
@@ -150,11 +150,9 @@ export def "gm clone" [
     ^git clone ...$args
 
     if (^git -C $local_path log | complete | get exit_code) != 0 {
-        print "it appears you have cloned an empty repository"
-        let res = ["yes", "no"] | input list --fuzzy "do you want to create an 'init' commit?"
-        if $res == "yes" {
-            ^git -C $local_path commit --allow-empty
-        }
+        print $"it appears you have cloned an (ansi yellow_bold)empty repository(ansi reset)"
+        print $"creating an (ansi cyan)'init' commit(ansi reset)"
+        ^git -C $local_path commit --allow-empty --message "init"
     }
 
     ^git -C $local_path remote set-url $remote $urls.fetch

--- a/pkgs/nu-git-manager/nu-git-manager/mod.nu
+++ b/pkgs/nu-git-manager/nu-git-manager/mod.nu
@@ -149,6 +149,14 @@ export def "gm clone" [
 
     ^git clone ...$args
 
+    if (^git -C $local_path log | complete | get exit_code) != 0 {
+        print "it appears you have cloned an empty repository"
+        let res = ["yes", "no"] | input list --fuzzy "do you want to create an 'init' commit?"
+        if $res == "yes" {
+            ^git -C $local_path commit --allow-empty
+        }
+    }
+
     ^git -C $local_path remote set-url $remote $urls.fetch
     ^git -C $local_path remote set-url $remote --push $urls.push
 


### PR DESCRIPTION
the error before
```
warning: You appear to have cloned an empty repository.
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Error: nu::shell::access_beyond_end

  × Row number too large (empty content).
    ╭─[/home/amtoine/.local/share/nupm/modules/nu-git-manager/git/repo.nu:24:44]
 23 │     let repo = $repo | default (pwd)
 24 │     (^git -C $repo rev-list HEAD | lines | last)
    ·                                            ──┬─
    ·                                              ╰── index too large (empty content)
 25 │ }
    ╰────
```

the cloning now
```
warning: You appear to have cloned an empty repository.
it appears you have cloned an empty repository
creating an 'init' commit
[main (root-commit) 8803d51] init
updating cache... done
```